### PR TITLE
Integrate automated Discord notifications for merges into dev branch

### DIFF
--- a/.github/workflows/notify-dev-merge.yml
+++ b/.github/workflows/notify-dev-merge.yml
@@ -1,0 +1,22 @@
+# .github/workflows/notify-dev-merge.yml
+name: Notify Discord on Merge to Dev
+
+on:
+  pull_request:
+    types: [ closed ]
+    branches:
+      - dev
+
+jobs:
+  notify:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Discord
+        run: |
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d '{
+                 "content": "🔔 **FastLanes update:** `${{ github.event.pull_request.title }}` was merged into `dev` by `${{ github.actor }}`.\n🔗 ${{ github.event.pull_request.html_url }}\n\n**PR Description:**\n${{ github.event.pull_request.body }}"
+               }' \
+               ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow that automatically sends a notification to our Discord channel whenever a pull request is merged into the dev branch. This keeps the community informed of key updates in real time, promoting better transparency and collaboration.



