### PR TITLE
Truncate Discord webhook messages at 2000 chars

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -24,7 +24,9 @@ jobs:
         run: |
           set -eo pipefail
 
-          if [[ "${{ github.event_name }}" == "pull_request_target" && "${{ github.event.action }}" == "closed" && "${{ github.event.pull_request.merged }}" == "true" ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request_target" && \
+                "${{ github.event.action }}" == "closed" && \
+                "${{ github.event.pull_request.merged }}" == "true" ]]; then
             # merged PR metadata
             MERGER=$(jq -r '.pull_request.merged_by.login' < "$GITHUB_EVENT_PATH")
             PR_NUMBER=$(jq -r '.pull_request.number'       < "$GITHUB_EVENT_PATH")
@@ -51,6 +53,12 @@ jobs:
               "${COMMIT_URL}"
           fi
 
+          # enforce Discord's 2000-character limit (reserve 3 chars for “…”)
+          MAX=2000
+          if (( ${#MSG} > MAX )); then
+            MSG="${MSG:0:MAX-3}…"
+          fi
+
           # wrap in compact JSON and expose
           JSON=$(jq -n -c --arg content "$MSG" '{content: $content}')
           echo "json=$JSON" >> "$GITHUB_OUTPUT"
@@ -74,8 +82,9 @@ jobs:
       - name: Send Discord notification
         env:
           PAYLOAD: ${{ needs.build-json.outputs.json }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
           curl -s -X POST \
                -H "Content-Type: application/json" \
                -d "$PAYLOAD" \
-               "${{ secrets.DISCORD_WEBHOOK_URL }}"
+               "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
This PR adds a truncation step to cap the first 2 000 characters of the Discord webhook `content` payload (reserving 3 for an ellipsis).


To verify the truncation, we’re including the full body text from PR #29 below—over 2 000 characters.

## Test Payload (from PR #29)

> **This PR introduces full support for IEEE-754 subnormal (denormal) floating-point values in FastLanes.**
>
> ### What are subnormal values?
>
> Subnormal numbers are extremely small non-zero floating-point values that lie between zero and the smallest normalized float. For float32, this range starts below approximately 1.175×10⁻³⁸ and goes down to around 1.4×10⁻⁴⁵. IEEE-754 defines these values to allow **gradual underflow**—so that results approaching zero lose precision smoothly, rather than jumping straight to zero.
>
> Supporting subnormals is important in scientific, signal-processing, and financial computations where very small values can accumulate or influence results.
>
> ### Motivation
>
> FastLanes used `std::stof` and `std::stod` to parse decimal float and double values. Unfortunately, these functions behave inconsistently with subnormals:
>
> * Many standard library implementations use the C library’s `strtof`/`strtod` underneath.  
> * When a valid subnormal is parsed, the underlying C function returns the correct value but sets `errno = ERANGE` (underflow).  
> * `std::stof` and `std::stod` interpret `errno = ERANGE` as a **fatal error**, and throw `std::out_of_range`—even though the value is perfectly valid.
>
> This led to runtime exceptions when parsing legitimate float values like `"8.7e-39"`—a classic subnormal.
>
> C++17 and C++20 introduced `std::from_chars` as a better alternative. It avoids exceptions, doesn't rely on `errno`, and handles subnormals correctly. However, many standard libraries (e.g. **macOS’s libc++**) did not implement the floating-point overloads of `std::from_chars` until recently, causing link-time errors if used unconditionally.
>
> ### This PR
>
> *  Uses `from_chars` on modern compilers with floating-point `std::from_chars` support. It is fast, allocation-free, exception-free, and correctly supports subnormals.  
> *  Falls back to `strtof` / `strtod` on platforms without `from_chars` for floats/doubles (e.g. macOS). These C functions handle subnormals correctly as long as `errno` is not misinterpreted.
>
> With this change, FastLanes can now safely and consistently parse all valid IEEE-754 floating-point values, including subnormals, across all supported platforms.

