### PR TITLE
Add FASTLANES_REPOSITORY in FetchContent example to point to the current repo

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -27,11 +27,16 @@ jobs:
         working-directory: examples/fetch_content_example
         run: |
           mkdir -p build && cd build
+          
+          echo "FASTLANES repository: ${{ github.event.pull_request.head.repo.clone_url || github.repository }}"
+          echo "FASTLANES tag/commit: ${{ github.event.pull_request.head.sha || github.sha }}"
+          
           cmake .. \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER=clang \
             -DCMAKE_CXX_COMPILER=clang++ \
             -DFLS_ENABLE_VERBOSE_OUTPUT=ON \
+            -DFASTLANES_REPOSITORY=${{ github.event.pull_request.head.repo.clone_url || github.repository }} \
             -DFASTLANES_TAG=${{ github.event.pull_request.head.sha || github.sha }}
           cmake --build . --parallel
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -28,7 +28,8 @@ jobs:
         run: |
           mkdir -p build && cd build
           
-          echo "FASTLANES repository: ${{ github.event.pull_request.head.repo.clone_url || github.repository }}"
+          # print what we’re about to fetch
+          echo "FASTLANES repository: ${{ github.event.pull_request.head.repo.clone_url || format('https://github.com/{0}.git', github.repository) }}"
           echo "FASTLANES tag/commit: ${{ github.event.pull_request.head.sha || github.sha }}"
           
           cmake .. \
@@ -36,7 +37,7 @@ jobs:
             -DCMAKE_C_COMPILER=clang \
             -DCMAKE_CXX_COMPILER=clang++ \
             -DFLS_ENABLE_VERBOSE_OUTPUT=ON \
-            -DFASTLANES_REPOSITORY=${{ github.event.pull_request.head.repo.clone_url || github.repository }} \
+            -DFASTLANES_REPOSITORY=${{ github.event.pull_request.head.repo.clone_url || format('https://github.com/{0}.git', github.repository) }} \
             -DFASTLANES_TAG=${{ github.event.pull_request.head.sha || github.sha }}
           cmake --build . --parallel
 

--- a/examples/fetch_content_example/CMakeLists.txt
+++ b/examples/fetch_content_example/CMakeLists.txt
@@ -5,10 +5,15 @@ if (NOT DEFINED FASTLANES_TAG)
     message(FATAL_ERROR "You must define FASTLANES_TAG")
 endif ()
 
+if (NOT DEFINED FASTLANES_REPOSITORY)
+    set(FATAL_ERROR "You must define FASTLANES_REPOSITORY")
+endif ()
+
+
 include(FetchContent)
 FetchContent_Declare(
         fastlanes
-        GIT_REPOSITORY https://github.com/azimafroozeh/FastLanes.git
+        GIT_REPOSITORY ${FASTLANES_REPOSITORY}
         GIT_TAG ${FASTLANES_TAG}
 )
 FetchContent_MakeAvailable(fastlanes)

--- a/mk/python.mk
+++ b/mk/python.mk
@@ -108,7 +108,7 @@ rebuild_python_release: check_python_deps $(ACTIVATE)
 	  $(PYTHON) -m pip install -e $(PROJECT_ROOT) --no-build-isolation -v
 	$(call echo_done,PyFastLanes bindings rebuilt (Release).)
 
-clean_python:
+clean-python:
 	$(call echo_start, Cleaning Python artefacts…)
 	rm -rf $(PROJECT_ROOT)/skbuild-editable $(DIST_DIR) $(VENV)
 	find $(PROJECT_ROOT)/python/pyfastlanes -name '_pyfastlanes*.so' -delete

--- a/mk/rust.mk
+++ b/mk/rust.mk
@@ -68,7 +68,7 @@ clean-vendor:
 	@rm -rf $(VENDOR_DIR)
 	@git rm -r --cached $(VENDOR_DIR) 2>/dev/null || true
 
-clean-rust: clean-vendor
+clean-rust:
 	@echo "Cleaning Rust build …"
 	$(CARGO) clean --manifest-path $(CRATE_ROOT)/Cargo.toml
 	@echo "Rust clean complete."


### PR DESCRIPTION
This PR introduces a `FASTLANES_REPOSITORY` CMake variable in the FetchContent example to allow overriding the Git repository used during CI builds. This ensures that FetchContent can correctly clone the repo where the workflow is actually running, which is especially important for pull requests from forks.