### PR TITLE
Add Support for JPEG Data Type

### DIFF
--- a/data/include/data/generated.hpp
+++ b/data/include/data/generated.hpp
@@ -27,7 +27,7 @@ public:
 	                                                      "/data/generated/single_columns/fls_timestamp"};
 	static constexpr string_view SINGLE_COLUMN_BYTE_ARRAY {FLS_CMAKE_SOURCE_DIR
 	                                                       "/data/generated/single_columns/byte_array"};
-
+	static constexpr string_view SINGLE_COLUMN_JPEG {FLS_CMAKE_SOURCE_DIR "/data/generated/single_columns/jpeg"};
 	//
 	static constexpr string_view EQUALITY_I64PT {FLS_CMAKE_SOURCE_DIR "/data/generated/equality/fls_i64"};
 	static constexpr string_view EQUALITY_DBLPT {FLS_CMAKE_SOURCE_DIR "/data/generated/equality/fls_dbl"};

--- a/flatbuffers_schemas/datatype.fbs
+++ b/flatbuffers_schemas/datatype.fbs
@@ -26,4 +26,5 @@ enum DataType : ubyte {
   FLS_STR    = 19,
   DECIMAL    = 20,
   TIMESTAMP   = 21,
+  JPEG = 22,
 }

--- a/scripts/generate_synthetic_data.py
+++ b/scripts/generate_synthetic_data.py
@@ -14,6 +14,7 @@ from generator_helpers.struct_generator import *
 from generator_helpers.list_generator import list_data
 from generator_helpers.write_helpers import *
 from generator_helpers.byte_array_generator import *
+from generator_helpers.jpeg_generator import *
 
 
 # ---------------------------
@@ -203,7 +204,7 @@ def generate_languages(faker, row_id):
 
 def generate_strings(faker, row_id):
     """Generates a list containing a single floating-point number."""
-    LIST = ["A","BB","CCC","DDDD"]
+    LIST = ["A", "BB", "CCC", "DDDD"]
     size = len(LIST)
     return [LIST[row_id % size]]
 
@@ -582,6 +583,7 @@ def generate_single_column():
     fls_date()
     fls_timestamp()
     byte_array_data()
+    jpeg_data()
 
 
 def generate_irregular_data():

--- a/scripts/generator_helpers/jpeg_generator.py
+++ b/scripts/generator_helpers/jpeg_generator.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+jpeg_generator.py – Dump Daisy JPEGs to a **pipe‑delimited** CSV with metadata
+and **JetBrains‑style “natural” filename ordering**.
+
+CLion (and other JetBrains IDEs) display files using a case‑insensitive natural
+sort: numeric parts are compared by value, so ``image2.jpg`` precedes
+``image10.jpg``.  This version mirrors that order when writing `data.csv` so
+rows line up with what you see in the Project tool‑window.
+
+CSV columns (pipe‑delimited)
+---------------------------
+1. ``id``       – 0‑based integer index (row number)
+2. ``filename`` – original file name
+3. ``image``    – base64‑encoded JPEG bytes
+
+The accompanying `schema.json` is unchanged.
+"""
+
+from __future__ import annotations
+
+import base64
+import csv
+import json
+import logging
+import re
+from pathlib import Path
+from typing import List, Tuple
+
+from faker import Faker  # retained for API symmetry across generators
+from .common import *  # shared logger / utilities
+
+__all__ = [
+    "generate_row",
+    "jpeg_data",
+]
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _natural_key(path: Path):
+    """Return a list key implementing JetBrains ‘natural’ filename ordering."""
+    name = path.name.lower()  # case‑insensitive like JetBrains
+    return [int(part) if part.isdigit() else part for part in re.split(r"(\d+)", name)]
+
+
+def _collect_jpeg_paths() -> List[Path]:
+    """Collect *.jpg / *.jpeg files and sort them with natural ordering."""
+    root = Path.cwd() / ".." / "data" / "flower_photos" / "daisy"
+    paths = list(root.glob("*.jpg")) + list(root.glob("*.jpeg"))
+    if not paths:
+        raise FileNotFoundError(f"No JPEG files found under {root.resolve()}")
+    return sorted(paths, key=_natural_key)
+
+
+_JPEG_PATHS: List[Path] = _collect_jpeg_paths()  # cache
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def generate_row(_faker: Faker, row_id: int) -> Tuple[int, str, str]:  # noqa: D401
+    """Return ``(id, filename, base64_string)`` cycling through images."""
+    if not _JPEG_PATHS:
+        raise RuntimeError("JPEG cache is empty – cannot generate rows.")
+
+    path = _JPEG_PATHS[row_id % len(_JPEG_PATHS)]
+    with path.open("rb") as fh:
+        encoded = base64.b64encode(fh.read()).decode("ascii")
+    return row_id, path.name, encoded
+
+
+def jpeg_data() -> None:
+    """Materialise the pipe‑delimited CSV + schema under the generated folder."""
+    out_dir = (
+            Path.cwd()
+            / ".."
+            / "data"
+            / "generated"
+            / "single_columns"
+            / "jpeg"
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    csv_path = out_dir / "data.csv"
+    logger.info("Writing pipe‑delimited CSV → %s  (%d rows)", csv_path, len(_JPEG_PATHS))
+    with csv_path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.writer(fh, delimiter="|", lineterminator="\n")
+        for row_id in range(len(_JPEG_PATHS)):
+            writer.writerow(generate_row(Faker(), row_id))
+
+    schema = {
+        "columns": [
+            {"name": "id", "type": "int"},
+            {"name": "filename", "type": "string"},
+            {
+                "name": "image",
+                "type": "jpeg",
+                "logical_type": "base64",
+                "content_type": "image/jpeg",
+            },
+        ]
+    }
+    schema_path = out_dir / "schema.json"
+    logger.info("Writing schema JSON → %s", schema_path)
+    with schema_path.open("w", encoding="utf-8") as sf:
+        json.dump(schema, sf, indent=2)
+
+
+if __name__ == "__main__":
+    jpeg_data()

--- a/scripts/show_image.py
+++ b/scripts/show_image.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""show_image.py – Preview a JPEG stored in a **pipe‑delimited** CSV.
+
+This script now aligns with the updated *jpeg_generator* output:
+• CSV delimiter is a **vertical bar ("|")**.
+• Base64 image lives in **column index 2** (after ``id`` and ``filename``).
+• Works as PyTest test (`pytest -s show_image.py`) and as a CLI utility.
+
+By default it loads the sample dataset generated under
+``../data/generated/single_columns/jpeg/data.csv`` but you can point it to any
+pipe‑delimited CSV with the same 3‑column layout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import sys
+from io import BytesIO
+from pathlib import Path
+from typing import Optional
+
+from PIL import Image
+
+# Allow very long base64 strings
+csv.field_size_limit(sys.maxsize)
+
+# ---------------------------------------------------------------------------
+# Config / paths
+# ---------------------------------------------------------------------------
+
+DEFAULT_RELATIVE_CSV = (
+        Path(__file__).resolve().parent
+        / ".."
+        / "data"
+        / "fls"
+        / "fastlanes.csv"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_csv(path_str: Optional[str]) -> Path:
+    """Return the absolute Path to the CSV, using default if *path_str* is None."""
+    return Path(path_str).expanduser().resolve() if path_str else DEFAULT_RELATIVE_CSV
+
+
+def _read_image_b64(csv_path: Path, index: int) -> str:
+    """Read row *index* from *csv_path* (pipe‑delimited) and return image column."""
+    if not csv_path.exists():
+        raise FileNotFoundError(f"CSV not found at {csv_path}")
+
+    with csv_path.open(encoding="utf-8", newline="") as fh:
+        reader = csv.reader(fh, delimiter="|")
+        for i, row in enumerate(reader):
+            if i == index:
+                try:
+                    return row[2]  # image column
+                except IndexError as exc:
+                    raise ValueError(
+                        f"Row {i} lacks expected 3 columns; got {row!r}"
+                    ) from exc
+        raise IndexError(f"CSV has only {i + 1} rows; index {index} is out of range")
+
+
+def _display_image(img: Image.Image, title: str) -> None:
+    """Prefer Matplotlib (if GUI backend available); fallback to OS viewer."""
+    try:
+        import matplotlib.pyplot as plt  # late import avoids backend issues
+
+        plt.imshow(img)
+        plt.axis("off")
+        plt.title(title)
+        plt.show(block=True)
+    except Exception as exc:  # pragma: no cover
+        print(f"Matplotlib display failed ({exc}); using PIL.Image.show()…")
+        img.show(title=title)
+
+
+# ---------------------------------------------------------------------------
+# PyTest‑compatible test
+# ---------------------------------------------------------------------------
+
+def test_show_image_row0() -> None:  # noqa: D401 – PyTest discovery
+    """Decode & display **row 0** (first image) – run with `pytest -s`."""
+    b64 = _read_image_b64(DEFAULT_RELATIVE_CSV, 0)
+    img = Image.open(BytesIO(base64.b64decode(b64)))
+
+    _display_image(img, "Row 0 – JPEG preview")
+
+    assert img.width > 0 and img.height > 0  # sanity check
+
+
+# ---------------------------------------------------------------------------
+# Command‑line interface
+# ---------------------------------------------------------------------------
+
+def _cli_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Preview a JPEG from a pipe‑delimited CSV")
+    parser.add_argument("-i", "--index", type=int, default=0, help="Row index (0‑based)")
+    parser.add_argument("--csv", type=str, default=None, help="Path to CSV file")
+    return parser.parse_args()
+
+
+def main(csv_path: Optional[str] = None, index: int = 0) -> None:  # noqa: D401
+    path = _resolve_csv(csv_path)
+    b64 = _read_image_b64(path, index)
+    img = Image.open(BytesIO(base64.b64decode(b64)))
+    _display_image(img, f"Row {index} – JPEG preview")
+
+
+if __name__ == "__main__":
+    args = _cli_args()
+    main(args.csv, args.index)

--- a/src/include/fls/cfg/cfg.hpp
+++ b/src/include/fls/cfg/cfg.hpp
@@ -44,7 +44,7 @@ public:
 		static constexpr uint64_t MAX_SIZE             = 4294967295; // max 32 bit unsigned integer
 		static constexpr uint64_t ADAPTIVE_TRY_C       = 3;          //
 		static constexpr double   ADAPTIVE_THRESHOLD   = 00.80;      //
-		static constexpr n_t      max_bytes_per_string = 15000;
+		static constexpr n_t      max_bytes_per_string = 2 * 1024 * 1024;
 	};
 
 	/* Sampler Config. */

--- a/src/include/fls/footer/datatype_generated.h
+++ b/src/include/fls/footer/datatype_generated.h
@@ -34,29 +34,30 @@ enum class DataType : uint8_t {
 	FALLBACK   = 18,
 	FLS_STR    = 19,
 	DECIMAL    = 20,
-	TIMESTAMP  = 21
+	TIMESTAMP  = 21,
+	JPEG       = 22
 };
 
-inline const DataType (&EnumValuesDataType())[22] {
-	static const DataType values[] = {DataType::INVALID, DataType::DOUBLE,   DataType::INT8,       DataType::INT16,
-	                                  DataType::INT32,   DataType::INT64,    DataType::UINT8,      DataType::UINT16,
-	                                  DataType::UINT32,  DataType::UINT64,   DataType::STR,        DataType::BOOLEAN,
-	                                  DataType::DATE,    DataType::FLOAT,    DataType::BYTE_ARRAY, DataType::LIST,
-	                                  DataType::STRUCT,  DataType::MAP,      DataType::FALLBACK,   DataType::FLS_STR,
-	                                  DataType::DECIMAL, DataType::TIMESTAMP};
+inline const DataType (&EnumValuesDataType())[23] {
+	static const DataType values[] = {DataType::INVALID, DataType::DOUBLE,    DataType::INT8,       DataType::INT16,
+	                                  DataType::INT32,   DataType::INT64,     DataType::UINT8,      DataType::UINT16,
+	                                  DataType::UINT32,  DataType::UINT64,    DataType::STR,        DataType::BOOLEAN,
+	                                  DataType::DATE,    DataType::FLOAT,     DataType::BYTE_ARRAY, DataType::LIST,
+	                                  DataType::STRUCT,  DataType::MAP,       DataType::FALLBACK,   DataType::FLS_STR,
+	                                  DataType::DECIMAL, DataType::TIMESTAMP, DataType::JPEG};
 	return values;
 }
 
 inline const char* const* EnumNamesDataType() {
-	static const char* const names[23] = {"INVALID",  "DOUBLE",  "INT8",       "INT16",     "INT32",  "INT64",
+	static const char* const names[24] = {"INVALID",  "DOUBLE",  "INT8",       "INT16",     "INT32",  "INT64",
 	                                      "UINT8",    "UINT16",  "UINT32",     "UINT64",    "STR",    "BOOLEAN",
 	                                      "DATE",     "FLOAT",   "BYTE_ARRAY", "LIST",      "STRUCT", "MAP",
-	                                      "FALLBACK", "FLS_STR", "DECIMAL",    "TIMESTAMP", nullptr};
+	                                      "FALLBACK", "FLS_STR", "DECIMAL",    "TIMESTAMP", "JPEG",   nullptr};
 	return names;
 }
 
 inline const char* EnumNameDataType(DataType e) {
-	if (::flatbuffers::IsOutRange(e, DataType::INVALID, DataType::TIMESTAMP))
+	if (::flatbuffers::IsOutRange(e, DataType::INVALID, DataType::JPEG))
 		return "";
 	const size_t index = static_cast<size_t>(e);
 	return EnumNamesDataType()[index];

--- a/src/json/fls_json.cpp
+++ b/src/json/fls_json.cpp
@@ -41,29 +41,15 @@ DataType TypeLookUp(const string& str) {
 	// 4) Static table of all the remaining fixed names (also all uppercase)
 	static const std::unordered_map<string, DataType> TABLE {
 	    // FLS types
-	    {"FLS_I64", DataType::INT64},
-	    {"FLS_I32", DataType::INT32},
-	    {"FLS_I16", DataType::INT16},
-	    {"FLS_I08", DataType::INT8},
-	    {"FLS_U08", DataType::UINT8},
-	    {"FLS_DBL", DataType::DOUBLE},
-	    {"FLS_STR", DataType::FLS_STR},
-	    {"BIGINT", DataType::INT64},
-	    {"STRING", DataType::FLS_STR},
-	    {"DOUBLE", DataType::DOUBLE},
-	    {"LIST", DataType::LIST},
-	    {"STRUCT", DataType::STRUCT},
-	    {"MAP", DataType::MAP},
-	    {"FLOAT", DataType::FLOAT},
-	    {"BOOLEAN", DataType::FLS_STR},
-	    {"INTEGER", DataType::INT64},
-	    {"CHAR", DataType::FLS_STR},
-	    {"BIGINT", DataType::INT64},
-	    {"TIME", DataType::FLS_STR},
-	    {"DATE", DataType::DATE},
-	    {"TIMESTAMP", DataType::TIMESTAMP},
-	    {"SMALLINT", DataType::INT16},
-	    {"BYTE_ARRAY", DataType::BYTE_ARRAY},
+	    {"FLS_I64", DataType::INT64},       {"FLS_I32", DataType::INT32},   {"INT", DataType::INT32},
+	    {"FLS_I16", DataType::INT16},       {"FLS_I08", DataType::INT8},    {"FLS_U08", DataType::UINT8},
+	    {"FLS_DBL", DataType::DOUBLE},      {"FLS_STR", DataType::FLS_STR}, {"BIGINT", DataType::INT64},
+	    {"STRING", DataType::FLS_STR},      {"DOUBLE", DataType::DOUBLE},   {"LIST", DataType::LIST},
+	    {"STRUCT", DataType::STRUCT},       {"MAP", DataType::MAP},         {"FLOAT", DataType::FLOAT},
+	    {"BOOLEAN", DataType::FLS_STR},     {"INTEGER", DataType::INT64},   {"CHAR", DataType::FLS_STR},
+	    {"BIGINT", DataType::INT64},        {"TIME", DataType::FLS_STR},    {"DATE", DataType::DATE},
+	    {"TIMESTAMP", DataType::TIMESTAMP}, {"SMALLINT", DataType::INT16},  {"BYTE_ARRAY", DataType::BYTE_ARRAY},
+	    {"JPEG", DataType::JPEG},
 
 	    // …add any other fixed names here…
 	};

--- a/src/table/rowgroup.cpp
+++ b/src/table/rowgroup.cpp
@@ -68,6 +68,8 @@ col_pt init_logical_columns(const ColumnDescriptorT& col_descriptor) {
 		return make_unique<col_i64>();
 	case DataType::BYTE_ARRAY:
 		return make_unique<FLSStrColumn>();
+	case DataType::JPEG:
+		return make_unique<FLSStrColumn>();
 	default:
 		FLS_UNREACHABLE();
 	}

--- a/src/wizard/wizard.cpp
+++ b/src/wizard/wizard.cpp
@@ -828,6 +828,10 @@ void expression_check_column(const rowgroup_pt&   rowgroup,
 		column_descriptor.encoding_rpn->operator_tokens.emplace_back(OperatorToken::EXP_UNCOMPRESSED_STR);
 		break;
 	}
+	case DataType::JPEG: {
+		column_descriptor.encoding_rpn->operator_tokens.emplace_back(OperatorToken::EXP_UNCOMPRESSED_STR);
+		break;
+	}
 	case DataType::STR:
 	case DataType::INVALID:
 	default:

--- a/test/src/dataset_tests/generated_data.cpp
+++ b/test/src/dataset_tests/generated_data.cpp
@@ -47,8 +47,13 @@ TEST_F(FastLanesReaderTester, SINGLE_COLUMN_DATE) {
 TEST_F(FastLanesReaderTester, SINGLE_COLUMN_TIMESTAMP) {
 	TestCorrectness(GENERATED::SINGLE_COLUMN_TIMESTAMP);
 }
+
 TEST_F(FastLanesReaderTester, SINGLE_COLUMN_BYTE_ARRAY) {
 	TestCorrectness(GENERATED::SINGLE_COLUMN_BYTE_ARRAY);
+}
+
+TEST_F(FastLanesReaderTester, SINGLE_COLUMN_JPEG) {
+	TestCorrectness(GENERATED::SINGLE_COLUMN_JPEG);
 }
 
 // All Constants


### PR DESCRIPTION
This PR adds native support for a new JPEG data type in FastLanes, enabling the storage and processing of raw JPEG file byte streams.