### PR TITLE
 Add quick fuzzy tests and expand CI matrix

### DIFF
--- a/.github/actions/generate-dataset/action.yml
+++ b/.github/actions/generate-dataset/action.yml
@@ -1,20 +1,38 @@
+# .github/actions/generate_dataset/action.yml
 name: Generate Synthetic Dataset
-
 description: Generate synthetic data and embeddings using Makefile targets
 
 runs:
   using: composite
   steps:
-    - name: Set up Python
+    # ─────────────────────────────────────────────────────────────
+    # 1️⃣  Use a Python version for which PyTorch publishes wheels
+    # ─────────────────────────────────────────────────────────────
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
         python-version: "3.12"
 
+    # ─────────────────────────────────────────────────────────────
+    # 2️⃣  Remove any .venv that might have been created earlier
+    #     with Python 3.13, so we always recreate it with 3.12.
+    # ─────────────────────────────────────────────────────────────
+    - name: Remove stale virtual-env
+      shell: bash
+      run: rm -rf "$GITHUB_WORKSPACE/.venv"
+
+    # ─────────────────────────────────────────────────────────────
+    # 3️⃣  Generate the synthetic data
+    # ─────────────────────────────────────────────────────────────
     - name: Generate synthetic data
       working-directory: mk
       shell: bash
       run: make -f data.mk generate_synthetic_data
 
+    # ─────────────────────────────────────────────────────────────
+    # 4️⃣  Generate the sentence embeddings
+    # ─────────────────────────────────────────────────────────────
     - name: Generate embeddings
+      working-directory: mk
       shell: bash
-      run: make -f mk/embeddings.mk generate
+      run: make -f embeddings.mk generate

--- a/.github/actions/install-llvm/action.yml
+++ b/.github/actions/install-llvm/action.yml
@@ -1,17 +1,50 @@
-# install-llvm/action.yml
+# .github/actions/install-llvm-toolchain/action.yml
+name: Install LLVM Toolchain
+description: Cross-platform LLVM installer for macOS, Ubuntu and Windows
 
-name: Install LLVM 20 Toolchain
-description: Cross-platform LLVM 20 installer for macOS and Ubuntu
+inputs:
+  version:
+    description: "Exact LLVM/Clang version to install, e.g. 18.1.4 or 18"
+    default: "18.1.4"   # macOS & Linux are happy with 18.x; Windows auto-bumps if too old
+
 runs:
   using: "composite"
   steps:
     - shell: bash
       run: |
+        set -euo pipefail
+        VERSION="${{ inputs.version }}"
+        MAJOR="${VERSION%%.*}"
+
+        echo "🟣 Installing LLVM/Clang ${VERSION} on ${{ runner.os }}"
+
         if [[ "${{ runner.os }}" == "macOS" ]]; then
-          brew install llvm
-          echo "/opt/homebrew/opt/llvm/bin" >> "$GITHUB_PATH"
+          # ── 1. Install LLVM (Homebrew) ────────────────────────────────────────
+          if brew info "llvm@${MAJOR}" > /dev/null 2>&1; then
+            brew install "llvm@${MAJOR}"
+            LLVM_PREFIX="$(brew --prefix "llvm@${MAJOR}")"
+          else
+            echo "::warning ::llvm@${MAJOR} formula not found – installing latest 'llvm' instead"
+            brew install llvm
+            LLVM_PREFIX="$(brew --prefix llvm)"
+          fi
+          echo "${LLVM_PREFIX}/bin" >> "$GITHUB_PATH"
+
+          # ── 2. Reclaim disk space so large static libs fit ───────────────────
+          echo "🧹 Freeing disk space on macOS runner …"
+          # Remove .NET (~6 GB) and Haskell (~3 GB)
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /opt/ghc         || true
+          # Delete cached iOS / tvOS simulators & Android SDK (~4 GB)
+          sudo rm -rf "$HOME/Library/Developer/CoreSimulator" || true
+          sudo rm -rf "$HOME/Library/Android"                 || true
+          # Remove old Homebrew download caches (~2 GB)
+          brew cleanup -s      || true
+          rm -rf "$(brew --cache)" || true
+          df -h
 
         elif [[ "${{ runner.os }}" == "Linux" ]]; then
+          # ── Ubuntu LTS ────────────────────────────────────────────────────────
           sudo apt-get update -y
           sudo apt-get install -y wget gnupg lsb-release software-properties-common
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | \
@@ -20,18 +53,33 @@ runs:
           UBUNTU_CODENAME=$(lsb_release -cs)
           echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] \
             http://apt.llvm.org/${UBUNTU_CODENAME}/ \
-            llvm-toolchain-${UBUNTU_CODENAME}-20 main" | \
-            sudo tee /etc/apt/sources.list.d/llvm20.list
+            llvm-toolchain-${UBUNTU_CODENAME}-${MAJOR} main" | \
+            sudo tee /etc/apt/sources.list.d/llvm${MAJOR}.list
 
           sudo apt-get update -y
-          sudo apt-get install -y clang-20 clang++-20 clang-tidy-20 lld-20
+          sudo apt-get install -y clang-${MAJOR} clang++-${MAJOR} clang-tidy-${MAJOR} lld-${MAJOR}
 
-          sudo update-alternatives --install /usr/bin/clang      clang      /usr/bin/clang-20       200
-          sudo update-alternatives --install /usr/bin/clang++    clang++    /usr/bin/clang++-20     200
-          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-20  200
+          sudo update-alternatives --install /usr/bin/clang      clang      /usr/bin/clang-${MAJOR}       200
+          sudo update-alternatives --install /usr/bin/clang++    clang++    /usr/bin/clang++-${MAJOR}     200
+          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-${MAJOR}  200
 
-          echo "/usr/lib/llvm-20/bin" >> "$GITHUB_PATH"
+          echo "/usr/lib/llvm-${MAJOR}/bin" >> "$GITHUB_PATH"
+
+        elif [[ "${{ runner.os }}" == "Windows" ]]; then
+          # ── Windows Server 2022 ──────────────────────────────────────────────
+          # MSVC STL (VS 2022 17.11+) needs Clang ≥19. Auto-bump if caller asks for less.
+          if [[ "${MAJOR}" -lt 19 ]]; then
+            echo "::notice ::Requested LLVM ${VERSION} is older than MSVC STL accepts; upgrading to LLVM 20.1.7"
+            VERSION="20.1.7"
+            MAJOR="20"
+          fi
+
+          echo "→ chocolatey upgrade llvm --version=${VERSION}"
+          choco upgrade llvm --version="${VERSION}" -y --no-progress --allow-downgrade
+
+          # Add to PATH; quoting keeps the space intact
+          echo 'C:\Program Files\LLVM\bin' >> "$GITHUB_PATH"
 
         else
-          echo "LLVM installation is not supported on this OS: ${{ runner.os }}"
+          echo "::warning ::LLVM install not supported on ${{ runner.os }}"
         fi

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,0 +1,88 @@
+name: Benchmarker
+run-name: >-
+  ${{ github.workflow }} on ${{ github.ref_name }} (#${{ github.run_number }})
+  — ${{ github.event.pull_request.title || github.event.head_commit.message }}
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+concurrency:
+  group: Benchmarker CI-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CMAKE_GENERATOR: Ninja
+
+jobs:
+  benchmark:
+    name: Run benchmarks (${{ matrix.platform }})
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ ubuntu-latest, macos-latest ]
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Detect CPU count
+        run: make detect-cpu | tee -a "$GITHUB_ENV"
+
+      - name: Install LLVM
+        uses: ./.github/actions/install-llvm
+
+      - name: Configure
+        run: |
+          cmake -S "${{ github.workspace }}" \
+                -B build \
+                -G "$CMAKE_GENERATOR" \
+                -DFLS_ENABLE_VERBOSE_OUTPUT=ON \
+                -DFLS_BUILD_BENCHMARKING=ON \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_C_COMPILER=clang \
+                -DCMAKE_CXX_COMPILER=clang++
+
+      - name: Build benchmarks
+        run: cmake --build build -j $BUILD_THREADS
+
+      - name: List build output
+        run: |
+          cd build/benchmark
+          ls -l
+
+      - name: Run bench_compression_ratio
+        run: build/benchmark/bench_compression_ratio
+
+      - name: Run benchmark_decompression_time
+        run: build/benchmark/benchmark_decompression_time
+
+      - name: Run benchmark_random_access
+        run: build/benchmark/benchmark_random_access
+
+      - name: Run bench_decoding_ffor
+        run: build/benchmark/bench_decoding_ffor
+
+      - name: Run micro_benchmark_decompression
+        run: build/benchmark/micro_benchmark_decompression
+
+      - name: Run bench_sample_size
+        run: build/benchmark/bench_sample_size
+
+      #      - name: Run bench_accuracy_over_rowgroups
+      #        run: build/benchmark/bench_accuracy_over_rowgroups
+      #
+      #      - name: Run bench_share_schema
+      #        run: build/benchmark/bench_share_schema
+
+      - name: Run bench_compression_time
+        run: build/benchmark/bench_compression_time

--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -44,7 +44,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ ubuntu-latest, macos-latest, windows-latest ]
+        platform:
+          - ubuntu-24.04
+          - ubuntu-22.04
+          - ubuntu-24.04-arm
+          - ubuntu-22.04-arm
+          - macos-15
+          - macos-14
+          - macos-13
         build_type: [ Debug, Release ]
         cxx: [ clang++ ]
         shared_lib: [ false, true ]
@@ -121,9 +128,17 @@ jobs:
   # 4️⃣  Synthetic-dataset generator (Python, cached pip)
   # ──────────────────────────────────────────────────────────────────────────────
   generate_dataset:
+    needs: build
     strategy:
       matrix:
-        platform: [ ubuntu-latest, macos-latest, windows-latest ]
+        platform:
+          - ubuntu-24.04
+          - ubuntu-22.04
+          - ubuntu-24.04-arm
+          - ubuntu-22.04-arm
+          - macos-15
+          - macos-14
+          - macos-13
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -140,7 +155,7 @@ jobs:
   # 5️⃣  Example build & run
   # ──────────────────────────────────────────────────────────────────────────────
   example:
-    needs: build
+#    needs: build
     strategy:
       matrix:
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
@@ -200,9 +215,18 @@ jobs:
   # 6️⃣  Tests (Linux + macOS, Release only)
   # ──────────────────────────────────────────────────────────────────────────────
   test:
+#    needs: build
+    name: test (${{ matrix.platform }}, ${{ matrix.build_type }}, ${{ matrix.shared_lib && 'shared' || 'static' }})
     strategy:
       matrix:
-        platform: [ ubuntu-latest, macos-latest ]
+        platform:
+          - ubuntu-24.04
+          - ubuntu-22.04
+          - ubuntu-24.04-arm
+          - ubuntu-22.04-arm
+          - macos-15
+          - macos-14
+          - macos-13
         build_type: [ Release ]
         shared_lib: [ false, true ]
     runs-on: ${{ matrix.platform }}
@@ -216,8 +240,16 @@ jobs:
         with:
           submodules: recursive
 
+      # Map the boolean shared_lib into a human-friendly label
+      - name: Determine lib label
+        run: |
+          if [[ "${{ matrix.shared_lib }}" == "true" ]]; then
+            echo "LIB_LABEL=shared" >> $GITHUB_ENV
+          else
+            echo "LIB_LABEL=static" >> $GITHUB_ENV
+          fi
+
       - name: Detect CPU count
-        shell: bash
         run: make detect-cpu | tee -a "$GITHUB_ENV"
 
       - name: Generate synthetic dataset
@@ -228,9 +260,11 @@ jobs:
 
       - name: Configure tests
         run: |
+          # Build directory uses our human-friendly label
+          BUILD_DIR="test_build_${LIB_LABEL}"
           CMAKE_ARGS=(
             -S "${{ github.workspace }}"
-            -B "test_build_${{ matrix.shared_lib }}"
+            -B "${BUILD_DIR}"
             -DFLS_BUILD_TESTING=ON
             -DFLS_ENABLE_VERBOSE_OUTPUT=ON
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
@@ -246,11 +280,19 @@ jobs:
           cmake "${CMAKE_ARGS[@]}"
 
       - name: Build tests
-        run: cmake --build "test_build_${{ matrix.shared_lib }}" -j $BUILD_THREADS
+        run: |
+          # Use the same labeled build directory
+          cmake --build "test_build_${LIB_LABEL}" -j $BUILD_THREADS
 
       - name: Run tests
-        working-directory: "test_build_${{ matrix.shared_lib }}"
-        run: ctest -j $BUILD_THREADS --stop-on-failure --output-on-failure --timeout 5000
+        working-directory: "test_build_${{ env.LIB_LABEL }}"
+        run: |
+          # Exclude Quick-Fuzz tests from the normal suite
+          ctest -j $BUILD_THREADS \
+                --stop-on-failure \
+                --output-on-failure \
+                --timeout 5000 \
+                -E "QuickFuzz"
 
   # ──────────────────────────────────────────────────────────────────────────────
   # 7️⃣  Install job

--- a/.github/workflows/quick-fuzz.yml
+++ b/.github/workflows/quick-fuzz.yml
@@ -1,0 +1,98 @@
+name: Quick-Fuzz CI
+run-name: >-
+  ${{ github.workflow }} on ${{ github.ref_name }}
+  (#${{ github.run_number }}) —
+  ${{ github.event.pull_request.title || github.event.head_commit.message }}
+
+on:
+  pull_request:
+    branches: [ dev ]
+    paths:
+      - '**/*.cpp'
+      - 'test/src/quick_fuzz_tests/fuzz_config.json'
+      - '.github/workflows/quick-fuzz.yml'
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1) Checkout the PR
+      - uses: actions/checkout@v4
+
+      # 2) Tool-chain
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake ninja-build jq python3
+
+      # 2½) Enforce base_seed was bumped by exactly +1 vs dev
+      - name: Verify base_seed bump
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin dev || true
+          python scripts/verify_seed_bump.py
+
+      # 3) Configure
+      - name: Configure
+        run: |
+          cmake -S . -B build -G Ninja \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DFLS_BUILD_TESTING=ON
+
+      # 4) Build
+      - name: Build
+        run: cmake --build build -- -j$(nproc)
+
+      # 5) Run Quick-Fuzz — job turns red if tests fail
+      - name: Run Quick-Fuzz
+        env:
+          CTEST_TEST_TIMEOUT: 0
+        run: |
+          set -o pipefail
+          ctest --test-dir build \
+                -R QuickFuzz \
+                --parallel $(nproc) \
+                --output-on-failure \
+                -V | tee ctest.log
+
+      # 6) Upload artefacts *only* when Quick-Fuzz failed
+      - name: Upload failure artefacts
+        id: upload
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quick-fuzz-failure-${{ github.run_id }}
+          path: |
+            tmp/fls_quick_fuzz/**
+            ctest.log
+
+      # 7) Comment on the PR with deep link to the ZIP
+      - name: Comment on failure
+        if: failure() &&
+          github.event_name == 'pull_request' &&
+          github.base_ref == 'dev'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR=${{ github.event.pull_request.number }}
+          RUN=${{ github.run_id }}
+          ART_ID=${{ steps.upload.outputs.artifact-id }}
+          HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          CONFIG_PATH='test/src/quick_fuzz_tests/fuzz_config.json'
+
+          ZIP_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${RUN}/artifacts/${ART_ID}"
+          CONFIG_URL="${{ github.server_url }}/${{ github.repository }}/blob/${HEAD_SHA}/${CONFIG_PATH}"
+          SNIPPET=$(tail -n 20 ctest.log)
+
+          gh pr comment "$PR" --body "$(printf '%s\n' \
+            '## ❌ Quick-Fuzz CI Failed' \
+            '' \
+            "[**⬇ Download artefact ZIP**](${ZIP_URL})" \
+            '' \
+            "[**Fuzz config**](${CONFIG_URL})" \
+            '' \
+            '**Last 20 lines of test log:**' \
+            '```' \
+            "${SNIPPET}" \
+            '```')"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ include(CMakePrintHelpers)
 set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED 1)
 include(CTest)
 include(GNUInstallDirs)
+include(enable_sanitizer)
 
 # Checks : -------------------------------------------------------------------------------------------------------
 if (NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
@@ -174,6 +175,9 @@ if (true)
     message("-- FLS: Building FastLanes Lib.")
 
     # Source: ----------------------------------------------------------------------------------------------------------
+    if (FLS_BUILD_SHARED_LIBS)
+        message("-- FLS: Shared is enabled!")
+    endif ()
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 endif ()
@@ -260,18 +264,6 @@ if (FLS_BUILD_TESTING)
     message("---------------------------------------------------------------------------------------------------------")
     message("-- FLS: Build Testing.")
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/test/include)
-
-    # Helper to apply sanitizer flags only on non-Windows platforms
-    function(fls_enable_sanitizers target)
-        if (NOT WIN32)
-            target_compile_options(${target}
-                    PRIVATE -fsanitize=address -fsanitize=undefined)
-            target_link_options(${target}
-                    PRIVATE -fsanitize=address -fsanitize=undefined)
-        endif ()
-    endfunction()
-
-
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/test)
 
 endif ()

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,31 +1,32 @@
 add_library(fastlanes_benchmarker SHARED benchmarker.cpp)
 target_include_directories(fastlanes_benchmarker PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(fastlanes_benchmarker PUBLIC FastLanes)
 
 add_library(FastLanes::benchmarker ALIAS fastlanes_benchmarker)
 
 add_executable(bench_compression_ratio bench_compression_ratio.cpp)
-target_link_libraries(bench_compression_ratio PUBLIC FastLanes FastLanes::benchmarker)
+target_link_libraries(bench_compression_ratio PUBLIC FastLanes::benchmarker)
 
-add_executable(benchmark_decompression_time benchmark_decompression_time.cpp)
-target_link_libraries(benchmark_decompression_time PUBLIC FastLanes FastLanes::benchmarker)
+add_executable(benchmark_decompression_time bench_decompression_time.cpp)
+target_link_libraries(benchmark_decompression_time PUBLIC FastLanes::benchmarker)
 
-add_executable(benchmark_random_access benchmark_random_access.cpp)
-target_link_libraries(benchmark_random_access PUBLIC FastLanes FastLanes::benchmarker)
+add_executable(benchmark_random_access bench_random_access.cpp)
+target_link_libraries(benchmark_random_access PUBLIC FastLanes::benchmarker)
 
 add_executable(bench_decoding_ffor bench_decoding_ffor.cpp)
-target_link_libraries(bench_decoding_ffor PUBLIC FastLanes FastLanes::benchmarker)
+target_link_libraries(bench_decoding_ffor PUBLIC FastLanes::benchmarker)
 
 add_executable(micro_benchmark_decompression micro_benchmark_decompression.cpp)
-target_link_libraries(micro_benchmark_decompression PUBLIC FastLanes FastLanes::benchmarker)
+target_link_libraries(micro_benchmark_decompression PUBLIC FastLanes::benchmarker)
 
 add_executable(bench_sample_size bench_sample_size.cpp)
-target_link_libraries(bench_sample_size PUBLIC FastLanes FastLanes::benchmarker)
+target_link_libraries(bench_sample_size PUBLIC FastLanes::benchmarker)
 
 add_executable(bench_accuracy_over_rowgroups bench_accuracy_over_rowgroups.cpp)
-target_link_libraries(bench_accuracy_over_rowgroups PUBLIC FastLanes FastLanes::benchmarker)
+target_link_libraries(bench_accuracy_over_rowgroups PUBLIC FastLanes::benchmarker)
 
 add_executable(bench_share_schema bench_shared_schema.cpp)
-target_link_libraries(bench_share_schema PUBLIC FastLanes FastLanes::benchmarker)
+target_link_libraries(bench_share_schema PUBLIC FastLanes::benchmarker)
 
 add_executable(bench_compression_time bench_compression_time.cpp)
-target_link_libraries(bench_compression_time PUBLIC FastLanes FastLanes::benchmarker)
+target_link_libraries(bench_compression_time PUBLIC FastLanes::benchmarker)

--- a/benchmark/bench_decoding_ffor.cpp
+++ b/benchmark/bench_decoding_ffor.cpp
@@ -3354,11 +3354,10 @@ void benchmark_all(benchmark::Benchmark& benchmark) {
 	benchmark.Run(bench123_unpack_64bw_64ow_64crw_1uf(packed64, unpacked64));
 }
 int main() {
-	benchmark::Benchmark benchmark =
-	    benchmark::create("fallback_scalar_av_1024_uf1_unffor")
-	        .save()
-	        .at(std::string(FLS_CMAKE_SOURCE_DIR) + "/fls_pub/results/" + benchmark::CmakeInfo::getCmakeToolchainFile())
-	        .print()
-	        .add_extra_info(benchmark::CmakeInfo::getCmakeInfo());
+	benchmark::Benchmark benchmark = benchmark::create("fallback_scalar_av_1024_uf1_unffor")
+	                                     .save()
+	                                     .at(std::string(FLS_CMAKE_SOURCE_DIR) + "/benchmark/result/microbenchmark")
+	                                     .print()
+	                                     .add_extra_info(benchmark::CmakeInfo::getCmakeInfo());
 	benchmark_all(benchmark);
 }

--- a/benchmark/include/benchmarker.hpp
+++ b/benchmark/include/benchmarker.hpp
@@ -16,6 +16,17 @@
 #include <vector>
 
 namespace fastlanes {
+
+inline void clear_directory(const fs::path& dir) {
+	if (!fs::exists(dir) || !fs::is_directory(dir))
+		return; // nothing to do
+
+	for (auto& entry : fs::directory_iterator(dir)) {
+		// remove files or entire subtrees
+		fs::remove_all(entry.path());
+	}
+}
+
 struct DetailedTableView {
 	std::string_view table_name;
 	std::string_view path;
@@ -50,8 +61,10 @@ public:
 
 		// Original rowgroup
 		Connection con1;
+		// Original rowgroup
+		const auto thread_specific_fls_file_path = thread_specific_fls_dir_path / "data.fls";
 		con1.reset().read_csv(dir_path).project(idxs);
-		con1.to_fls(thread_specific_fls_dir_path);
+		con1.to_fls(thread_specific_fls_file_path);
 	}
 	// Method to write a table's data to a thread-specific FLS directory
 	void Write(const string_view file_path, const path& thread_specific_fls_dir_path, n_t sample_size) const {
@@ -62,8 +75,9 @@ public:
 
 		// Original rowgroup
 		Connection con1;
+		const auto thread_specific_fls_file_path = thread_specific_fls_dir_path / "data.fls";
 		con1.reset().read_csv(dir_path);
-		con1.set_sample_size(sample_size).to_fls(thread_specific_fls_dir_path);
+		con1.set_sample_size(sample_size).to_fls(thread_specific_fls_file_path);
 	}
 	// Method to write a table's data to a thread-specific FLS directory
 	void Write(const string_view            file_path,
@@ -76,8 +90,9 @@ public:
 
 		// Original rowgroup
 		Connection con1;
+		const auto thread_specific_fls_file_path = thread_specific_fls_dir_path / "data.fls";
 		con1.reset().read_csv(dir_path);
-		con1.force_schema(operator_tokens).to_fls(thread_specific_fls_dir_path);
+		con1.force_schema(operator_tokens).to_fls(thread_specific_fls_file_path);
 	}
 
 	// Method to get the footer for the thread-specific directory

--- a/cmake/enable_sanitizer.cmake
+++ b/cmake/enable_sanitizer.cmake
@@ -1,0 +1,68 @@
+# --- cmake/enable_sanitizer.cmake ---
+#
+# Defines fls_enable_sanitizers(<target>) to apply
+# AddressSanitizer, UBSan, and related checks on all builds
+# *except* fully‐static macOS executables, which are unsupported,
+# and on Win32 where Clang’s sanitizers aren’t reliably supported.
+#
+# RATIONALE:
+#   • ASan on Apple platforms is provided only as a dynamic
+#     runtime (libclang_rt.asan_osx_dynamic.dylib).
+#   • Clang docs state: “Static linking of executables is
+#     not supported.”
+#   • On macOS-14 (Sonoma) & macOS-15 (Ventura), a truly
+#     static binary with -fsanitize=address will abort at
+#     startup (you see the shadow-byte legend then “ABORTING”).
+#   • Linux “static” builds still load the dynamic libasan,
+#     so only macOS static+ASan fails.
+#   • On **Win32**, neither MSVC nor Clang-on-Windows reliably
+#     supports the standard `-fsanitize=` flags by default:
+#       – MSVC uses a different sanitization framework
+#         (AddressSanitizer on Windows is still experimental).
+#       – ODR-use of sanitizers can break the CRT linkage.
+#     Disabling on Win32 avoids build errors and linkage issues.
+#
+# IMPACT ON CI:
+#   OS         | Shared        | Static
+#   -----------------------------------------
+#   Ubuntu     | ✅ ASan       | ✅ ASan
+#   macOS-14   | ✅ ASan       | ❌ Abort at startup
+#   macOS-15   | ✅ ASan       | ❌ Abort at startup
+#   Windows    | 🚫 Sanitizers | 🚫 Sanitizers
+#
+
+function(fls_enable_sanitizers target)
+    # 1) Skip on static macOS
+    if (APPLE AND NOT FLS_BUILD_SHARED_LIBS)
+        message(STATUS
+                "[Sanitizers] Skipping sanitizers for '${target}' "
+                "(static build on macOS is unsupported by ASan)")
+        return()
+    endif ()
+
+    # 2) Skip on Win32 due to lack of reliable -fsanitize support
+    if (WIN32)
+        message(STATUS
+                "[Sanitizers] Skipping sanitizers for '${target}' "
+                "(sanitizer flags not supported on Win32 toolchains)")
+        return()
+    endif ()
+
+    # 3) Apply on all other platforms
+    set(_san_flags
+            -fsanitize=address
+            -fsanitize=undefined
+            -fsanitize=vptr
+            -fsanitize=function
+            -fsanitize=null
+            -fno-sanitize-recover=all
+            -fno-omit-frame-pointer
+    )
+
+    string(REPLACE ";" " " _san_flags_str "${_san_flags}")
+    message(STATUS
+            "[Sanitizers] Enabling sanitizers for '${target}': ${_san_flags_str}")
+
+    target_compile_options(${target} PRIVATE ${_san_flags})
+    target_link_options(${target} PRIVATE ${_san_flags})
+endfunction()

--- a/data/include/data/NextiaJD.hpp
+++ b/data/include/data/NextiaJD.hpp
@@ -1,7 +1,6 @@
 #ifndef DATA_NEXTIAJD_HPP
 #define DATA_NEXTIAJD_HPP
 
-#include "fls/std/string.hpp"
 #include <array>
 #include <string_view>
 

--- a/data/include/data/clickbench.hpp
+++ b/data/include/data/clickbench.hpp
@@ -1,14 +1,14 @@
 #ifndef DATA_CLICKBENCH_HPP
 #define DATA_CLICKBENCH_HPP
 
-#include "fls/std/string.hpp"
+#include <string>
 
 namespace fastlanes {
 
 // clang-format off
 class clickbench {
 public:
-	static constexpr string_view hits {FASTLANES_DATA_DIR "/clickbench/hits"}; //NOLINT
+	static constexpr std::string_view hits {FASTLANES_DATA_DIR "/clickbench/hits"}; //NOLINT
             
 };
 } // namespace fastlanes

--- a/data/include/data/embedding.hpp
+++ b/data/include/data/embedding.hpp
@@ -1,15 +1,15 @@
 #ifndef DATA_EMBEDDING_HPP
 #define DATA_EMBEDDING_HPP
 
-#include "fls/std/string.hpp"
 #include <array>
+#include <string>
 
 namespace fastlanes {
-using EMBEDDING_DATASET_dataset_t = std::array<std::pair<string_view, string_view>, 1>;
+using EMBEDDING_DATASET_dataset_t = std::array<std::pair<std::string_view, std::string_view>, 1>;
 
 class EMBEDDING {
 public:
-	static constexpr string_view N1 {FLS_CMAKE_SOURCE_DIR "/data/embedding/"};
+	static constexpr std::string_view N1 {FLS_CMAKE_SOURCE_DIR "/data/embedding/"};
 };
 } // namespace fastlanes
 

--- a/data/include/data/example.hpp
+++ b/data/include/data/example.hpp
@@ -1,15 +1,15 @@
 #ifndef DATA_EXAMPLE_HPP
 #define DATA_EXAMPLE_HPP
 
-#include "fls/std/string.hpp"
 #include <array>
+#include <string>
 
 namespace fastlanes {
-using EXAMPLE_DATASET_dataset_t = std::array<std::pair<string_view, string_view>, 1>;
+using EXAMPLE_DATASET_dataset_t = std::array<std::pair<std::string_view, std::string_view>, 1>;
 
 class EXAMPLE {
 public:
-	static constexpr string_view N1 {FLS_CMAKE_SOURCE_DIR "/data/example/"};
+	static constexpr std::string_view N1 {FLS_CMAKE_SOURCE_DIR "/data/example/"};
 };
 } // namespace fastlanes
 

--- a/data/include/data/fannie_mae.hpp
+++ b/data/include/data/fannie_mae.hpp
@@ -1,15 +1,15 @@
 #ifndef DATA_FANNIE_MAE_HPP
 #define DATA_FANNIE_MAE_HPP
 
-#include "fls/std/string.hpp"
 #include <array>
+#include <string>
 
 namespace fastlanes {
-using fannie_mae_dataset_t = std::array<std::pair<string_view, string_view>, 1>;
+using fannie_mae_dataset_t = std::array<std::pair<std::string_view, std::string_view>, 1>;
 
 class fannie_mae {
 public:
-	static constexpr string_view table_2024Q3 {FASTLANES_DATA_DIR "/fannie_mae/2024Q3"};
+	static constexpr std::string_view table_2024Q3 {FASTLANES_DATA_DIR "/fannie_mae/2024Q3"};
 
 	static constexpr fannie_mae_dataset_t dataset = {{
 	    {"table_2024Q3", table_2024Q3},

--- a/data/include/data/fc_bench.hpp
+++ b/data/include/data/fc_bench.hpp
@@ -1,15 +1,15 @@
 #ifndef DATA_FC_BENCH_HPP
 #define DATA_FC_BENCH_HPP
 
-#include "fls/std/string.hpp"
 #include <array>
+#include <string>
 
 namespace fastlanes {
-using fc_bench_dataset_t = std::array<std::pair<string_view, string_view>, 1>;
+using fc_bench_dataset_t = std::array<std::pair<std::string_view, std::string_view>, 1>;
 
 class fc_bench {
 public:
-	static constexpr string_view fc_bench_sample {FASTLANES_DATA_DIR "/fc_bench"};
+	static constexpr std::string_view fc_bench_sample {FASTLANES_DATA_DIR "/fc_bench"};
 
 	static constexpr fc_bench_dataset_t dataset = {{
 	    {"fc_bench", fc_bench_sample},

--- a/data/include/data/generated.hpp
+++ b/data/include/data/generated.hpp
@@ -1,75 +1,90 @@
 #ifndef DATA_GENERATED_HPP
 #define DATA_GENERATED_HPP
 
-#include "fls/std/string.hpp"
+#include <string>
 
 namespace fastlanes {
 
 class GENERATED {
 public:
-	static constexpr string_view CCC_ONE_TO_ONE_MAP {FLS_CMAKE_SOURCE_DIR "/data/generated/one_to_one"};
-	static constexpr string_view ALL_CONSTANT {FLS_CMAKE_SOURCE_DIR "/data/generated/all_constant"};
-	static constexpr string_view STRUCT {FLS_CMAKE_SOURCE_DIR "/data/generated/struct"};
+	static constexpr std::string_view CCC_ONE_TO_ONE_MAP {FLS_CMAKE_SOURCE_DIR "/data/generated/one_to_one"};
+	static constexpr std::string_view ALL_CONSTANT {FLS_CMAKE_SOURCE_DIR "/data/generated/all_constant"};
+	static constexpr std::string_view STRUCT {FLS_CMAKE_SOURCE_DIR "/data/generated/struct"};
 
 	// SINGLE COLUMN
-	static constexpr string_view SINGLE_COLUMN_I64PT {FLS_CMAKE_SOURCE_DIR "/data/generated/single_columns/fls_i64"};
-	static constexpr string_view SINGLE_COLUMN_I32PT {FLS_CMAKE_SOURCE_DIR "/data/generated/single_columns/fls_i32"};
-	static constexpr string_view SINGLE_COLUMN_I08PT {FLS_CMAKE_SOURCE_DIR "/data/generated/single_columns/fls_i08"};
-	static constexpr string_view SINGLE_COLUMN_DBLPT {FLS_CMAKE_SOURCE_DIR "/data/generated/single_columns/fls_dbl"};
-	static constexpr string_view SINGLE_COLUMN_STRPT {FLS_CMAKE_SOURCE_DIR "/data/generated/single_columns/fls_str"};
-	static constexpr string_view SINGLE_COLUMN_U08PT {FLS_CMAKE_SOURCE_DIR "/data/generated/single_columns/fls_u08"};
-	static constexpr string_view SINGLE_COLUMN_DECIMAL {FLS_CMAKE_SOURCE_DIR "/data/generated/single_columns/decimal"};
-	static constexpr string_view SINGLE_COLUMN_FLOAT {FLS_CMAKE_SOURCE_DIR "/data/generated/single_columns/float"};
-	static constexpr string_view SINGLE_COLUMN_IRREGULAR_I64 {FLS_CMAKE_SOURCE_DIR
-	                                                          "/data/generated/single_columns/irregular_i64"};
-	static constexpr string_view SINGLE_COLUMN_DATE {FLS_CMAKE_SOURCE_DIR "/data/generated/single_columns/fls_date"};
-	static constexpr string_view SINGLE_COLUMN_TIMESTAMP {FLS_CMAKE_SOURCE_DIR
-	                                                      "/data/generated/single_columns/fls_timestamp"};
-	static constexpr string_view SINGLE_COLUMN_BYTE_ARRAY {FLS_CMAKE_SOURCE_DIR
-	                                                       "/data/generated/single_columns/byte_array"};
-	static constexpr string_view SINGLE_COLUMN_JPEG {FLS_CMAKE_SOURCE_DIR "/data/generated/single_columns/jpeg"};
+	static constexpr std::string_view SINGLE_COLUMN_I64PT {FLS_CMAKE_SOURCE_DIR
+	                                                       "/data/generated/single_columns/fls_i64"};
+	static constexpr std::string_view SINGLE_COLUMN_I32PT {FLS_CMAKE_SOURCE_DIR
+	                                                       "/data/generated/single_columns/fls_i32"};
+	static constexpr std::string_view SINGLE_COLUMN_I08PT {FLS_CMAKE_SOURCE_DIR
+	                                                       "/data/generated/single_columns/fls_i08"};
+	static constexpr std::string_view SINGLE_COLUMN_DBLPT {FLS_CMAKE_SOURCE_DIR
+	                                                       "/data/generated/single_columns/fls_dbl"};
+	static constexpr std::string_view SINGLE_COLUMN_STRPT {FLS_CMAKE_SOURCE_DIR
+	                                                       "/data/generated/single_columns/fls_str"};
+	static constexpr std::string_view SINGLE_COLUMN_U08PT {FLS_CMAKE_SOURCE_DIR
+	                                                       "/data/generated/single_columns/fls_u08"};
+	static constexpr std::string_view SINGLE_COLUMN_DECIMAL {FLS_CMAKE_SOURCE_DIR
+	                                                         "/data/generated/single_columns/decimal"};
+	static constexpr std::string_view SINGLE_COLUMN_FLOAT {FLS_CMAKE_SOURCE_DIR "/data/generated/single_columns/float"};
+	static constexpr std::string_view SINGLE_COLUMN_IRREGULAR_I64 {FLS_CMAKE_SOURCE_DIR
+	                                                               "/data/generated/single_columns/irregular_i64"};
+	static constexpr std::string_view SINGLE_COLUMN_DATE {FLS_CMAKE_SOURCE_DIR
+	                                                      "/data/generated/single_columns/fls_date"};
+	static constexpr std::string_view SINGLE_COLUMN_TIMESTAMP {FLS_CMAKE_SOURCE_DIR
+	                                                           "/data/generated/single_columns/fls_timestamp"};
+	static constexpr std::string_view SINGLE_COLUMN_BYTE_ARRAY {FLS_CMAKE_SOURCE_DIR
+	                                                            "/data/generated/single_columns/byte_array"};
+	static constexpr std::string_view SINGLE_COLUMN_JPEG {FLS_CMAKE_SOURCE_DIR "/data/generated/single_columns/jpeg"};
 	//
-	static constexpr string_view EQUALITY_I64PT {FLS_CMAKE_SOURCE_DIR "/data/generated/equality/fls_i64"};
-	static constexpr string_view EQUALITY_DBLPT {FLS_CMAKE_SOURCE_DIR "/data/generated/equality/fls_dbl"};
-	static constexpr string_view EQUALITY_STRPT {FLS_CMAKE_SOURCE_DIR "/data/generated/equality/fls_str"};
-	static constexpr string_view ALL_TYPES {FLS_CMAKE_SOURCE_DIR "/data/generated/all_types"};
-	static constexpr string_view X_PLUS_Y_EQUAL_Z {FLS_CMAKE_SOURCE_DIR "/data/generated/whitebox/x_plus_y_equal_z"};
+	static constexpr std::string_view EQUALITY_I64PT {FLS_CMAKE_SOURCE_DIR "/data/generated/equality/fls_i64"};
+	static constexpr std::string_view EQUALITY_DBLPT {FLS_CMAKE_SOURCE_DIR "/data/generated/equality/fls_dbl"};
+	static constexpr std::string_view EQUALITY_STRPT {FLS_CMAKE_SOURCE_DIR "/data/generated/equality/fls_str"};
+	static constexpr std::string_view ALL_TYPES {FLS_CMAKE_SOURCE_DIR "/data/generated/all_types"};
+	static constexpr std::string_view X_PLUS_Y_EQUAL_Z {FLS_CMAKE_SOURCE_DIR
+	                                                    "/data/generated/whitebox/x_plus_y_equal_z"};
 
 	// ONE VEC
-	static constexpr string_view ONE_VEC_I64PT {FLS_CMAKE_SOURCE_DIR "/data/generated/one_vector/fls_i64"};
-	static constexpr string_view ONE_VEC_I32PT {FLS_CMAKE_SOURCE_DIR "/data/generated/one_vector/fls_i32"};
-	static constexpr string_view ONE_VEC_I08PT {FLS_CMAKE_SOURCE_DIR "/data/generated/one_vector/fls_i08"};
-	static constexpr string_view ONE_VEC_STRPT {FLS_CMAKE_SOURCE_DIR "/data/generated/one_vector/fls_str"};
-	static constexpr string_view ONE_VEC_DBLPT {FLS_CMAKE_SOURCE_DIR "/data/generated/one_vector/fls_dbl"};
-	static constexpr string_view ONE_VEC_DECIMAL {FLS_CMAKE_SOURCE_DIR "/data/generated/one_vector/decimal"};
+	static constexpr std::string_view ONE_VEC_I64PT {FLS_CMAKE_SOURCE_DIR "/data/generated/one_vector/fls_i64"};
+	static constexpr std::string_view ONE_VEC_I32PT {FLS_CMAKE_SOURCE_DIR "/data/generated/one_vector/fls_i32"};
+	static constexpr std::string_view ONE_VEC_I08PT {FLS_CMAKE_SOURCE_DIR "/data/generated/one_vector/fls_i08"};
+	static constexpr std::string_view ONE_VEC_STRPT {FLS_CMAKE_SOURCE_DIR "/data/generated/one_vector/fls_str"};
+	static constexpr std::string_view ONE_VEC_DBLPT {FLS_CMAKE_SOURCE_DIR "/data/generated/one_vector/fls_dbl"};
+	static constexpr std::string_view ONE_VEC_DECIMAL {FLS_CMAKE_SOURCE_DIR "/data/generated/one_vector/decimal"};
 
 	// TWO VEC
-	static constexpr string_view TWO_VEC_STRPT {FLS_CMAKE_SOURCE_DIR "/data/generated/two_vector/fls_str"};
+	static constexpr std::string_view TWO_VEC_STRPT {FLS_CMAKE_SOURCE_DIR "/data/generated/two_vector/fls_str"};
 
 	// MOSTLY NULL
-	static constexpr string_view MOSTLY_NULL {FLS_CMAKE_SOURCE_DIR "/data/generated/mostly_null"};
+	static constexpr std::string_view MOSTLY_NULL {FLS_CMAKE_SOURCE_DIR "/data/generated/mostly_null"};
 
 	// ENCODINGS
-	static constexpr string_view FSST_DICT_U16_EXPR {FLS_CMAKE_SOURCE_DIR "/data/generated/encodings/fsst_dict_u16"};
-	static constexpr string_view FREQUENCY_DBL_EXPR {FLS_CMAKE_SOURCE_DIR "/data/generated/encodings/frequency_dbl"};
-	static constexpr string_view FREQUENCY_STR_EXPR {FLS_CMAKE_SOURCE_DIR "/data/generated/encodings/frequency_str"};
-	static constexpr string_view EXP_CROSS_RLE_i16 {FLS_CMAKE_SOURCE_DIR "/data/generated/encodings/cross_rle_i16"};
-	static constexpr string_view EXP_CROSS_RLE_STR {FLS_CMAKE_SOURCE_DIR "/data/generated/encodings/cross_rle_str"};
-	static constexpr string_view EXP_ALP_FLT {FLS_CMAKE_SOURCE_DIR "/data/generated/encodings/alp_flt"};
-	static constexpr string_view EXP_ALP_DBL {FLS_CMAKE_SOURCE_DIR "/data/generated/encodings/alp_dbl"};
+	static constexpr std::string_view FSST_DICT_U16_EXPR {FLS_CMAKE_SOURCE_DIR
+	                                                      "/data/generated/encodings/fsst_dict_u16"};
+	static constexpr std::string_view FREQUENCY_DBL_EXPR {FLS_CMAKE_SOURCE_DIR
+	                                                      "/data/generated/encodings/frequency_dbl"};
+	static constexpr std::string_view FREQUENCY_STR_EXPR {FLS_CMAKE_SOURCE_DIR
+	                                                      "/data/generated/encodings/frequency_str"};
+	static constexpr std::string_view EXP_CROSS_RLE_i16 {FLS_CMAKE_SOURCE_DIR
+	                                                     "/data/generated/encodings/cross_rle_i16"};
+	static constexpr std::string_view EXP_CROSS_RLE_STR {FLS_CMAKE_SOURCE_DIR
+	                                                     "/data/generated/encodings/cross_rle_str"};
+	static constexpr std::string_view EXP_ALP_FLT {FLS_CMAKE_SOURCE_DIR "/data/generated/encodings/alp_flt"};
+	static constexpr std::string_view EXP_ALP_DBL {FLS_CMAKE_SOURCE_DIR "/data/generated/encodings/alp_dbl"};
 
 	//
-	static constexpr string_view NUMBER_STRINGS {FLS_CMAKE_SOURCE_DIR "/data/generated/whitebox/number_strings"};
-	static constexpr string_view DECIMAL_DOUBLES {FLS_CMAKE_SOURCE_DIR "/data/generated/whitebox/decimal_doubles"};
+	static constexpr std::string_view NUMBER_STRINGS {FLS_CMAKE_SOURCE_DIR "/data/generated/whitebox/number_strings"};
+	static constexpr std::string_view DECIMAL_DOUBLES {FLS_CMAKE_SOURCE_DIR "/data/generated/whitebox/decimal_doubles"};
 
 	// Any count value
-	static constexpr string_view ANY_VALUE_COUNT_I64_1 {FLS_CMAKE_SOURCE_DIR "/data/generated/any_value_count/1"};
-	static constexpr string_view ANY_VALUE_COUNT_I64_666 {FLS_CMAKE_SOURCE_DIR "/data/generated/any_value_count/666"};
-	static constexpr string_view ANY_VALUE_COUNT_I64_52422 {FLS_CMAKE_SOURCE_DIR
-	                                                        "/data/generated/any_value_count/25570"};
+	static constexpr std::string_view ANY_VALUE_COUNT_I64_1 {FLS_CMAKE_SOURCE_DIR "/data/generated/any_value_count/1"};
+	static constexpr std::string_view ANY_VALUE_COUNT_I64_666 {FLS_CMAKE_SOURCE_DIR
+	                                                           "/data/generated/any_value_count/666"};
+	static constexpr std::string_view ANY_VALUE_COUNT_I64_52422 {FLS_CMAKE_SOURCE_DIR
+	                                                             "/data/generated/any_value_count/25570"};
 
 	// SUBNORMAL
-	static constexpr string_view SUBNORMALS {FLS_CMAKE_SOURCE_DIR "/data/generated/subnormals"};
+	static constexpr std::string_view SUBNORMALS {FLS_CMAKE_SOURCE_DIR "/data/generated/subnormals"};
 };
 
 } // namespace fastlanes

--- a/data/include/data/issues.hpp
+++ b/data/include/data/issues.hpp
@@ -1,18 +1,19 @@
 #ifndef DATA_ISSUES_HPP
 #define DATA_ISSUES_HPP
 
-#include "fls/std/string.hpp"
 #include <array>
+#include <string>
 
 namespace fastlanes {
-using issues_dataset_t = std::array<std::pair<string_view, string_view>, 3>;
+using issues_dataset_t = std::array<std::pair<std::string_view, std::string_view>, 3>;
 
 class issues {
 public:
-	static constexpr string_view issues_cwida_alp_37_kv_cache_original {FASTLANES_DATA_DIR
-	                                                                    "/issues/cwida/alp/37/kv_cache_original"};
-	static constexpr string_view issues_cwida_alp_37_diff_data {FASTLANES_DATA_DIR "/issues/cwida/alp/37/diff_data"};
-	static constexpr string_view ISSUE_000 {FLS_CMAKE_SOURCE_DIR "/data/issues/issue_000/"};
+	static constexpr std::string_view issues_cwida_alp_37_kv_cache_original {FASTLANES_DATA_DIR
+	                                                                         "/issues/cwida/alp/37/kv_cache_original"};
+	static constexpr std::string_view issues_cwida_alp_37_diff_data {FASTLANES_DATA_DIR
+	                                                                 "/issues/cwida/alp/37/diff_data"};
+	static constexpr std::string_view ISSUE_000 {FLS_CMAKE_SOURCE_DIR "/data/issues/issue_000/"};
 	//
 	static constexpr issues_dataset_t dataset = {{
 	    {"issues_cwida_alp_37_kv_cache_original", issues_cwida_alp_37_kv_cache_original},

--- a/data/include/data/public_bi.hpp
+++ b/data/include/data/public_bi.hpp
@@ -1,52 +1,52 @@
 #ifndef DATA_PUBLIC_BI_HPP
 #define DATA_PUBLIC_BI_HPP
 
-#include "fls/std/string.hpp"
 #include <array>
+#include <string>
 
 namespace fastlanes {
-using public_bi_dataset_t = std::array<std::pair<string_view, string_view>, 36>;
+using public_bi_dataset_t = std::array<std::pair<std::string_view, std::string_view>, 36>;
 
 // clang-format off
 class public_bi {
 public:
-    // Define all the string_view constants for paths
-	static constexpr string_view Arade {FASTLANES_DATA_DIR "/public_bi/tables/Arade/Arade_1"}; //NOLINT
-	static constexpr string_view Bimbo {FASTLANES_DATA_DIR "/public_bi/tables/Bimbo/Bimbo_1"}; //NOLINT
-	static constexpr string_view CMSprovider {FASTLANES_DATA_DIR "/public_bi/tables/CMSprovider/CMSprovider_1"}; //NOLINT
-	static constexpr string_view CityMaxCapita {FASTLANES_DATA_DIR "/public_bi/tables/CityMaxCapita/CityMaxCapita_1"}; //NOLINT
-	static constexpr string_view CommonGovernment {FASTLANES_DATA_DIR "/public_bi/tables/CommonGovernment/CommonGovernment_1"}; //NOLINT
-	static constexpr string_view Corporations {FASTLANES_DATA_DIR "/public_bi/tables/Corporations/Corporations_1"}; //NOLINT
-	static constexpr string_view Eixo {FASTLANES_DATA_DIR "/public_bi/tables/Eixo/Eixo_1"}; //NOLINT
-	static constexpr string_view Euro2016 {FASTLANES_DATA_DIR "/public_bi/tables/Euro2016/Euro2016_1"}; //NOLINT
-	static constexpr string_view Food {FASTLANES_DATA_DIR "/public_bi/tables/Food/Food_1"}; //NOLINT
-	static constexpr string_view Generico {FASTLANES_DATA_DIR "/public_bi/tables/Generico/Generico_1"}; //NOLINT
-	static constexpr string_view HashTags {FASTLANES_DATA_DIR "/public_bi/tables/HashTags/HashTags_1"}; //NOLINT
-	static constexpr string_view Hatred {FASTLANES_DATA_DIR "/public_bi/tables/Hatred/Hatred_1"}; //NOLINT
-	static constexpr string_view IGlocations1 {FASTLANES_DATA_DIR "/public_bi/tables/IGlocations1/IGlocations1_1"}; //NOLINT
-	static constexpr string_view MLB {FASTLANES_DATA_DIR "/public_bi/tables/MLB/MLB_1"}; //NOLINT
-	static constexpr string_view MedPayment1 {FASTLANES_DATA_DIR "/public_bi/tables/MedPayment1/MedPayment1_1"}; //NOLINT
-	static constexpr string_view Medicare1 {FASTLANES_DATA_DIR "/public_bi/tables/Medicare1/Medicare1_1"}; //NOLINT
-	static constexpr string_view Motos {FASTLANES_DATA_DIR "/public_bi/tables/Motos/Motos_1"}; //NOLINT
-	static constexpr string_view MulheresMil {FASTLANES_DATA_DIR "/public_bi/tables/MulheresMil/MulheresMil_1"}; //NOLINT
-	static constexpr string_view NYC {FASTLANES_DATA_DIR "/public_bi/tables/NYC/NYC_1"}; //NOLINT
-	static constexpr string_view PanCreactomy1 {FASTLANES_DATA_DIR "/public_bi/tables/PanCreactomy1/PanCreactomy1_1"}; //NOLINT
-	static constexpr string_view Physicians {FASTLANES_DATA_DIR "/public_bi/tables/Physicians/Physicians_1"}; //NOLINT
-	static constexpr string_view Provider {FASTLANES_DATA_DIR "/public_bi/tables/Provider/Provider_1"}; //NOLINT
-	static constexpr string_view RealEstate1 {FASTLANES_DATA_DIR "/public_bi/tables/RealEstate1/RealEstate1_1"}; //NOLINT
-	static constexpr string_view Redfin1 {FASTLANES_DATA_DIR "/public_bi/tables/Redfin1/Redfin1_1"}; //NOLINT
-	static constexpr string_view Rentabilidad {FASTLANES_DATA_DIR "/public_bi/tables/Rentabilidad/Rentabilidad_1"}; //NOLINT
-	static constexpr string_view Romance {FASTLANES_DATA_DIR "/public_bi/tables/Romance/Romance_1"}; //NOLINT
-	static constexpr string_view SalariesFrance {FASTLANES_DATA_DIR "/public_bi/tables/SalariesFrance/SalariesFrance_1"}; //NOLINT
-	static constexpr string_view TableroSistemaPenal {FASTLANES_DATA_DIR "/public_bi/tables/TableroSistemaPenal/TableroSistemaPenal_1"}; //NOLINT
-	static constexpr string_view Taxpayer {FASTLANES_DATA_DIR "/public_bi/tables/Taxpayer/Taxpayer_1"}; //NOLINT
-	static constexpr string_view Telco {FASTLANES_DATA_DIR "/public_bi/tables/Telco/Telco_1"}; //NOLINT
-	static constexpr string_view TrainsUK1 {FASTLANES_DATA_DIR "/public_bi/tables/TrainsUK1/TrainsUK1_2"}; //NOLINT
-	static constexpr string_view TrainsUK2 {FASTLANES_DATA_DIR "/public_bi/tables/TrainsUK2/TrainsUK2_1"}; //NOLINT
-	static constexpr string_view USCensus {FASTLANES_DATA_DIR "/public_bi/tables/USCensus/USCensus_1"}; //NOLINT
-	static constexpr string_view Uberlandia {FASTLANES_DATA_DIR "/public_bi/tables/Uberlandia/Uberlandia_1"}; //NOLINT
-	static constexpr string_view Wins {FASTLANES_DATA_DIR "/public_bi/tables/Wins/Wins_1"}; //NOLINT
-	static constexpr string_view YaleLanguages {FASTLANES_DATA_DIR "/public_bi/tables/YaleLanguages/YaleLanguages_1"}; //NOLINT
+    // Define all the std::string_view constants for paths
+	static constexpr std::string_view Arade {FASTLANES_DATA_DIR "/public_bi/tables/Arade/Arade_1"}; //NOLINT
+	static constexpr std::string_view Bimbo {FASTLANES_DATA_DIR "/public_bi/tables/Bimbo/Bimbo_1"}; //NOLINT
+	static constexpr std::string_view CMSprovider {FASTLANES_DATA_DIR "/public_bi/tables/CMSprovider/CMSprovider_1"}; //NOLINT
+	static constexpr std::string_view CityMaxCapita {FASTLANES_DATA_DIR "/public_bi/tables/CityMaxCapita/CityMaxCapita_1"}; //NOLINT
+	static constexpr std::string_view CommonGovernment {FASTLANES_DATA_DIR "/public_bi/tables/CommonGovernment/CommonGovernment_1"}; //NOLINT
+	static constexpr std::string_view Corporations {FASTLANES_DATA_DIR "/public_bi/tables/Corporations/Corporations_1"}; //NOLINT
+	static constexpr std::string_view Eixo {FASTLANES_DATA_DIR "/public_bi/tables/Eixo/Eixo_1"}; //NOLINT
+	static constexpr std::string_view Euro2016 {FASTLANES_DATA_DIR "/public_bi/tables/Euro2016/Euro2016_1"}; //NOLINT
+	static constexpr std::string_view Food {FASTLANES_DATA_DIR "/public_bi/tables/Food/Food_1"}; //NOLINT
+	static constexpr std::string_view Generico {FASTLANES_DATA_DIR "/public_bi/tables/Generico/Generico_1"}; //NOLINT
+	static constexpr std::string_view HashTags {FASTLANES_DATA_DIR "/public_bi/tables/HashTags/HashTags_1"}; //NOLINT
+	static constexpr std::string_view Hatred {FASTLANES_DATA_DIR "/public_bi/tables/Hatred/Hatred_1"}; //NOLINT
+	static constexpr std::string_view IGlocations1 {FASTLANES_DATA_DIR "/public_bi/tables/IGlocations1/IGlocations1_1"}; //NOLINT
+	static constexpr std::string_view MLB {FASTLANES_DATA_DIR "/public_bi/tables/MLB/MLB_1"}; //NOLINT
+	static constexpr std::string_view MedPayment1 {FASTLANES_DATA_DIR "/public_bi/tables/MedPayment1/MedPayment1_1"}; //NOLINT
+	static constexpr std::string_view Medicare1 {FASTLANES_DATA_DIR "/public_bi/tables/Medicare1/Medicare1_1"}; //NOLINT
+	static constexpr std::string_view Motos {FASTLANES_DATA_DIR "/public_bi/tables/Motos/Motos_1"}; //NOLINT
+	static constexpr std::string_view MulheresMil {FASTLANES_DATA_DIR "/public_bi/tables/MulheresMil/MulheresMil_1"}; //NOLINT
+	static constexpr std::string_view NYC {FASTLANES_DATA_DIR "/public_bi/tables/NYC/NYC_1"}; //NOLINT
+	static constexpr std::string_view PanCreactomy1 {FASTLANES_DATA_DIR "/public_bi/tables/PanCreactomy1/PanCreactomy1_1"}; //NOLINT
+	static constexpr std::string_view Physicians {FASTLANES_DATA_DIR "/public_bi/tables/Physicians/Physicians_1"}; //NOLINT
+	static constexpr std::string_view Provider {FASTLANES_DATA_DIR "/public_bi/tables/Provider/Provider_1"}; //NOLINT
+	static constexpr std::string_view RealEstate1 {FASTLANES_DATA_DIR "/public_bi/tables/RealEstate1/RealEstate1_1"}; //NOLINT
+	static constexpr std::string_view Redfin1 {FASTLANES_DATA_DIR "/public_bi/tables/Redfin1/Redfin1_1"}; //NOLINT
+	static constexpr std::string_view Rentabilidad {FASTLANES_DATA_DIR "/public_bi/tables/Rentabilidad/Rentabilidad_1"}; //NOLINT
+	static constexpr std::string_view Romance {FASTLANES_DATA_DIR "/public_bi/tables/Romance/Romance_1"}; //NOLINT
+	static constexpr std::string_view SalariesFrance {FASTLANES_DATA_DIR "/public_bi/tables/SalariesFrance/SalariesFrance_1"}; //NOLINT
+	static constexpr std::string_view TableroSistemaPenal {FASTLANES_DATA_DIR "/public_bi/tables/TableroSistemaPenal/TableroSistemaPenal_1"}; //NOLINT
+	static constexpr std::string_view Taxpayer {FASTLANES_DATA_DIR "/public_bi/tables/Taxpayer/Taxpayer_1"}; //NOLINT
+	static constexpr std::string_view Telco {FASTLANES_DATA_DIR "/public_bi/tables/Telco/Telco_1"}; //NOLINT
+	static constexpr std::string_view TrainsUK1 {FASTLANES_DATA_DIR "/public_bi/tables/TrainsUK1/TrainsUK1_2"}; //NOLINT
+	static constexpr std::string_view TrainsUK2 {FASTLANES_DATA_DIR "/public_bi/tables/TrainsUK2/TrainsUK2_1"}; //NOLINT
+	static constexpr std::string_view USCensus {FASTLANES_DATA_DIR "/public_bi/tables/USCensus/USCensus_1"}; //NOLINT
+	static constexpr std::string_view Uberlandia {FASTLANES_DATA_DIR "/public_bi/tables/Uberlandia/Uberlandia_1"}; //NOLINT
+	static constexpr std::string_view Wins {FASTLANES_DATA_DIR "/public_bi/tables/Wins/Wins_1"}; //NOLINT
+	static constexpr std::string_view YaleLanguages {FASTLANES_DATA_DIR "/public_bi/tables/YaleLanguages/YaleLanguages_1"}; //NOLINT
 
 	static constexpr public_bi_dataset_t dataset = {{
 		{"Arade", Arade},

--- a/data/include/data/sdrbench.hpp
+++ b/data/include/data/sdrbench.hpp
@@ -1,15 +1,15 @@
 #ifndef DATA_SDRBENCH_HPP
 #define DATA_SDRBENCH_HPP
 
-#include "fls/std/string.hpp"
 #include <array>
+#include <string>
 
 namespace fastlanes {
-using sdrbnech_dataset_t = std::array<std::pair<string_view, string_view>, 1>;
+using sdrbnech_dataset_t = std::array<std::pair<std::string_view, std::string_view>, 1>;
 
 class sdrbnech {
 public:
-	static constexpr string_view hurricane_isabel {FASTLANES_DATA_DIR "/sdrbench/Hurricane_ISABEL"};
+	static constexpr std::string_view hurricane_isabel {FASTLANES_DATA_DIR "/sdrbench/Hurricane_ISABEL"};
 
 	static constexpr sdrbnech_dataset_t dataset = {{
 	    {"hurricane_isabel", hurricane_isabel},

--- a/data/include/data/test.hpp
+++ b/data/include/data/test.hpp
@@ -1,15 +1,15 @@
 #ifndef DATA_TEST_HPP
 #define DATA_TEST_HPP
 
-#include "fls/std/string.hpp"
 #include <array>
+#include <string>
 
 namespace fastlanes {
 
 /* ---------------------------------------------------------------------------
    Helper aliases
    -------------------------------------------------------------------------*/
-using dataset_entry_t = std::pair<string_view, string_view>;
+using dataset_entry_t = std::pair<std::string_view, std::string_view>;
 using test_dataset_t  = std::array<dataset_entry_t, 6>;
 
 /* ---------------------------------------------------------------------------
@@ -18,22 +18,23 @@ using test_dataset_t  = std::array<dataset_entry_t, 6>;
 class test_dataset {
 public:
 	// Absolute or CMake-relative paths (CMake sets FLS_CMAKE_SOURCE_DIR)
-	static constexpr string_view VALID_FLS {FLS_CMAKE_SOURCE_DIR "/data/test/verify_fastlanes_file_tests/valid.fls"};
+	static constexpr std::string_view VALID_FLS {FLS_CMAKE_SOURCE_DIR
+	                                             "/data/test/verify_fastlanes_file_tests/valid.fls"};
 
-	static constexpr string_view BAD_HEADER_MAGIC {FLS_CMAKE_SOURCE_DIR
-	                                               "/data/test/verify_fastlanes_file_tests/bad_header_magic.fls"};
+	static constexpr std::string_view BAD_HEADER_MAGIC {FLS_CMAKE_SOURCE_DIR
+	                                                    "/data/test/verify_fastlanes_file_tests/bad_header_magic.fls"};
 
-	static constexpr string_view BAD_FOOTER_MAGIC {FLS_CMAKE_SOURCE_DIR
-	                                               "/data/test/verify_fastlanes_file_tests/bad_footer_magic.fls"};
+	static constexpr std::string_view BAD_FOOTER_MAGIC {FLS_CMAKE_SOURCE_DIR
+	                                                    "/data/test/verify_fastlanes_file_tests/bad_footer_magic.fls"};
 
-	static constexpr string_view BAD_VERSION {FLS_CMAKE_SOURCE_DIR
-	                                          "/data/test/verify_fastlanes_file_tests/bad_version.fls"};
+	static constexpr std::string_view BAD_VERSION {FLS_CMAKE_SOURCE_DIR
+	                                               "/data/test/verify_fastlanes_file_tests/bad_version.fls"};
 
-	static constexpr string_view MISSING_FOOTER {FLS_CMAKE_SOURCE_DIR
-	                                             "/data/test/verify_fastlanes_file_tests/missing_footer.fls"};
+	static constexpr std::string_view MISSING_FOOTER {FLS_CMAKE_SOURCE_DIR
+	                                                  "/data/test/verify_fastlanes_file_tests/missing_footer.fls"};
 
-	static constexpr string_view TRUNCATED_HEADER {FLS_CMAKE_SOURCE_DIR
-	                                               "/data/test/verify_fastlanes_file_tests/truncated_header.fls"};
+	static constexpr std::string_view TRUNCATED_HEADER {FLS_CMAKE_SOURCE_DIR
+	                                                    "/data/test/verify_fastlanes_file_tests/truncated_header.fls"};
 
 	// Handy iterable for parameterised tests
 	static constexpr test_dataset_t dataset = {{{"VALID_FLS", VALID_FLS},

--- a/data/include/data/tpch.hpp
+++ b/data/include/data/tpch.hpp
@@ -1,20 +1,20 @@
 #ifndef DATA_TPCH_HPP
 #define DATA_TPCH_HPP
 
-#include "fls/std/string.hpp"
 #include <array>
+#include <string>
 
 namespace fastlanes {
 
-using tpch_dataset_t = std::array<std::pair<string_view, string_view>, 5>;
+using tpch_dataset_t = std::array<std::pair<std::string_view, std::string_view>, 5>;
 
 class Tpch {
 public:
-	static constexpr string_view customer {FASTLANES_DATA_DIR "/tpch/tables/customer"}; // NOLINT
-	static constexpr string_view lineitem {FASTLANES_DATA_DIR "/tpch/tables/lineitem"}; // NOLINT
-	static constexpr string_view orders {FASTLANES_DATA_DIR "/tpch/tables/orders"};     // NOLINT
-	static constexpr string_view part {FASTLANES_DATA_DIR "/tpch/tables/part"};         // NOLINT
-	static constexpr string_view partsupp {FASTLANES_DATA_DIR "/tpch/tables/partsupp"}; // NOLINT
+	static constexpr std::string_view customer {FASTLANES_DATA_DIR "/tpch/tables/customer"}; // NOLINT
+	static constexpr std::string_view lineitem {FASTLANES_DATA_DIR "/tpch/tables/lineitem"}; // NOLINT
+	static constexpr std::string_view orders {FASTLANES_DATA_DIR "/tpch/tables/orders"};     // NOLINT
+	static constexpr std::string_view part {FASTLANES_DATA_DIR "/tpch/tables/part"};         // NOLINT
+	static constexpr std::string_view partsupp {FASTLANES_DATA_DIR "/tpch/tables/partsupp"}; // NOLINT
 
 	static constexpr tpch_dataset_t dataset = {
 	    {{"customer", customer}, {"lineitem", lineitem}, {"orders", orders}, {"part", part}, {"partsupp", partsupp}}};

--- a/data/include/data/wrong_schema.hpp
+++ b/data/include/data/wrong_schema.hpp
@@ -1,13 +1,13 @@
 #ifndef DATA_WRONG_SCHEMA_HPP
 #define DATA_WRONG_SCHEMA_HPP
 
-#include "fls/std/string.hpp"
+#include <string>
 
 namespace fastlanes {
 
 class WRONG_SCHEMA {
 public:
-	static constexpr string_view FLOAT {FLS_CMAKE_SOURCE_DIR "/data/wrong_schema/float"};
+	static constexpr std::string_view FLOAT {FLS_CMAKE_SOURCE_DIR "/data/wrong_schema/float"};
 };
 } // namespace fastlanes
 

--- a/scripts/bump_fuzz_seed.py
+++ b/scripts/bump_fuzz_seed.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""
+Bump the `base_seed` in test/src/quick_fuzz_tests/fuzz_config.json by +1.
+
+Usage:
+    python scripts/bump_fuzz_seed.py
+"""
+from __future__ import annotations
+import json
+from pathlib import Path
+import sys
+import tempfile
+
+CFG = Path("test/src/quick_fuzz_tests/fuzz_config.json")
+DEFAULT_SEED = 42
+
+def main() -> None:
+    if not CFG.exists():
+        print(f"⚠️  {CFG} not found; creating with base_seed={DEFAULT_SEED}")
+        CFG.parent.mkdir(parents=True, exist_ok=True)
+        data = {"base_seed": DEFAULT_SEED}
+    else:
+        data = json.loads(CFG.read_text())
+
+    old = data.get("base_seed", DEFAULT_SEED)
+    new = old + 1
+    data["base_seed"] = new
+
+    with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+        json.dump(data, tmp, indent=2)
+        tmp.write("\n")
+    Path(tmp.name).replace(CFG)
+
+    print(f"✅  base_seed bumped: {old} → {new}")
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_seed_bump.py
+++ b/scripts/verify_seed_bump.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+CI helper: ensure the PR's base_seed is exactly +1 over dev's base_seed.
+
+If the config is absent on dev, the check is skipped (passes).
+"""
+
+from __future__ import annotations
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+CFG_PATH = "test/src/quick_fuzz_tests/fuzz_config.json"
+DEFAULT_SEED = 42
+
+def read_seed_from_string(s: str) -> int:
+    try:
+        return json.loads(s or "{}").get("base_seed", DEFAULT_SEED)
+    except json.JSONDecodeError:
+        return DEFAULT_SEED
+
+def main() -> None:
+    cfg = Path(CFG_PATH)
+    if not cfg.exists():
+        print("ℹ️  No fuzz_config.json in this PR – skipping seed-bump check.")
+        return
+
+    pr_seed = read_seed_from_string(cfg.read_text())
+
+    # Try to fetch the file from origin/dev
+    try:
+        dev_file = subprocess.check_output(
+            ["git", "show", f"origin/dev:{CFG_PATH}"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        dev_seed = read_seed_from_string(dev_file)
+    except subprocess.CalledProcessError:
+        print("ℹ️  No fuzz_config.json on dev branch – skipping seed-bump check.")
+        return
+
+    expected = dev_seed + 1
+    if pr_seed != expected:
+        print(
+            f"::error title=Seed bump required::'base_seed' should be {expected} "
+            f"(found {pr_seed}).\n"
+            f"Please run `python scripts/bump_fuzz_seed.py` and commit."
+        )
+        sys.exit(1)
+
+    print(f"✔️  base_seed correctly bumped ({dev_seed} → {pr_seed})")
+
+if __name__ == "__main__":
+    main()

--- a/src/common/decimal.cpp
+++ b/src/common/decimal.cpp
@@ -1,6 +1,5 @@
 #include "fls/common/decimal.hpp"
 #include <cmath>
-#include <format>
 #include <regex>
 
 namespace fastlanes {
@@ -17,7 +16,7 @@ std::string clean_numeric_string(const std::string& input) {
 }
 
 int64_t make_decimal(const std::string& value, n_t scale) {
-	std::string cleaned_value = clean_numeric_string(value); // ✅ Remove unwanted characters
+	std::string cleaned_value = clean_numeric_string(value); // Remove unwanted characters
 
 	// Ensure we still have a valid numeric string
 	if (cleaned_value.empty() || cleaned_value == "-" || cleaned_value == ".") {
@@ -33,14 +32,14 @@ int64_t make_decimal(const std::string& value, n_t scale) {
 	const size_t dot_pos           = abs_value.find('.');
 	const n_t    fractional_digits = (dot_pos == std::string::npos) ? 0 : abs_value.size() - dot_pos - 1;
 
-	// ❌ If the input has more decimals than `scale`, throw an exception
+	// If the input has more decimals than `scale`, throw an exception
 	if (fractional_digits > scale) {
 		throw std::invalid_argument("Input has more decimal places than allowed scale: " + cleaned_value);
 	}
 
-	// ✅ Use std::round() to avoid precision issues
+	// Use std::round() to avoid precision issues
 	const auto scaled_value = static_cast<double>(std::stold(cleaned_value)) * std::pow(10, scale);
-	const auto int_value    = static_cast<int64_t>(std::round(scaled_value)); // ✅ Fix: Round before conversion
+	const auto int_value    = static_cast<int64_t>(std::round(scaled_value)); // Round before conversion
 
 	return int_value;
 }
@@ -56,7 +55,7 @@ up<DecimalTypeT> make_decimal_t(const std::string& value) {
 		dt->scale      = scale;
 		return dt;
 	}
-	throw std::invalid_argument(std::format("Invalid decimal format: {}", value));
+	throw std::invalid_argument("Invalid decimal format: " + value);
 }
 
 } // namespace fastlanes

--- a/src/expression/encoding_operator.cpp
+++ b/src/expression/encoding_operator.cpp
@@ -60,14 +60,23 @@ void enc_dict_map_opr<VALUE_PT, INDEX_PT>::PointTo(n_t vec_idx) {
 
 template <typename VALUE_PT, typename INDEX_PT>
 void enc_dict_map_opr<VALUE_PT, INDEX_PT>::Map() {
-	[[maybe_unused]] const auto& bimap_frequency =
-	    typed_column_view.GetStats()->bimap_frequency; // todo get bimap_frequency from bimap_frequency operator
+	// 1) Stats must exist
+	const auto* stats = typed_column_view.GetStats();
+	if (!stats) {
+		throw std::runtime_error("typed_column_view.GetStats() returned null");
+	}
+	const auto& bimap_frequency = stats->bimap_frequency;
 
+	// 2) Data pointer must exist
 	const auto* value_p = typed_column_view.Data();
+	if (!value_p) {
+		throw std::runtime_error("typed_column_view.Data() returned null");
+	}
 
 	for (auto idx = 0; idx < CFG::VEC_SZ; ++idx) {
 		const auto value = value_p[idx];
-		index_arr[idx]   = static_cast<INDEX_PT>(bimap_frequency.get_key(value));
+		// wrap get_key in try/catch if your bimap might throw
+		index_arr[idx] = static_cast<INDEX_PT>(bimap_frequency.get_key(value));
 	}
 }
 

--- a/src/include/fls/csv/csv-parser/parser.hpp
+++ b/src/include/fls/csv/csv-parser/parser.hpp
@@ -17,7 +17,7 @@
 #include <vector>
 
 namespace aria { namespace csv {
-enum class Term : char { CRLF = -2 };
+enum class Term : int8_t { CRLF = -2 };
 enum class FieldType { DATA, ROW_END, CSV_END };
 using CSV = std::vector<std::vector<std::string>>;
 

--- a/src/types/date.cpp
+++ b/src/types/date.cpp
@@ -2,7 +2,7 @@
 #include <array>
 #include <charconv>
 #include <chrono>
-#include <format>
+#include <cstdio> // for std::snprintf
 #include <stdexcept>
 #include <string_view>
 
@@ -68,8 +68,14 @@ std::string date_formatter(const int32_t days_since_epoch) {
 	if (!ymd.ok()) {
 		throw std::runtime_error("days_since_epoch out of range");
 	}
-	// Format as "YYYY-MM-DD"
-	return std::format("{:%Y-%m-%d}", ymd);
+
+	int      y = static_cast<int>(ymd.year());
+	unsigned m = static_cast<unsigned>(ymd.month());
+	unsigned d = static_cast<unsigned>(ymd.day());
+
+	char buf[11]; // "YYYY-MM-DD" + '\0'
+	std::snprintf(buf, sizeof(buf), "%04d-%02u-%02u", y, m, d);
+	return std::string(buf);
 }
 
 } // namespace fastlanes

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -2,5 +2,6 @@ add_subdirectory(dataset_tests)
 add_subdirectory(expression_tests)
 add_subdirectory(fls_reader_tests)
 add_subdirectory(primitive_tests)
+add_subdirectory(quick_fuzz_tests)
 add_subdirectory(unit_tests)
 

--- a/test/src/dataset_tests/CMakeLists.txt
+++ b/test/src/dataset_tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(
         dataset_tests
         #
-        embedding.cpp
+        #        embedding.cpp
         generated_data.cpp
         issues.cpp
         nextiajd_test.cpp

--- a/test/src/quick_fuzz_tests/CMakeLists.txt
+++ b/test/src/quick_fuzz_tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+include(GoogleTest)                   # keep only once in the whole tree
+
+add_executable(quick_fuzz_test
+        quick_fuzz_test.cpp)
+
+target_link_libraries(quick_fuzz_test
+        PRIVATE
+        GTest::gtest_main
+        FastLanes)
+
+fls_enable_sanitizers(quick_fuzz_test)
+
+gtest_discover_tests(
+        quick_fuzz_test
+
+        # --- 1️⃣  DROP the second --gtest_filter -----------------
+        # Leave only the flag you really need below
+        EXTRA_ARGS
+        --gtest_also_run_disabled_tests  # (optional; keep if you want this)
+        # --- 2️⃣  ADD a prefix so CI can match names cleanly ------
+        TEST_PREFIX QuickFuzz_               # final names like "QuickFuzz_QuickFuzz_Case0.Random"
+        PROPERTIES
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        DISCOVERY_TIMEOUT 30
+)

--- a/test/src/quick_fuzz_tests/fuzz_config.json
+++ b/test/src/quick_fuzz_tests/fuzz_config.json
@@ -1,0 +1,9 @@
+{
+  "num_cases": 10,
+  "base_seed": 0,
+  "delimiter": "|",
+  "min_cols": 1,
+  "max_cols": 2,
+  "min_rows": 65536,
+  "max_rows": 65536
+}

--- a/test/src/quick_fuzz_tests/quick_fuzz_test.cpp
+++ b/test/src/quick_fuzz_tests/quick_fuzz_test.cpp
@@ -1,0 +1,268 @@
+#include "fls/connection.hpp"
+#include "fls/csv/csv-parser/parser.hpp"
+#include "fls/json/nlohmann/json.hpp"
+#include "fls/std/filesystem.hpp"
+#include <fstream>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace fs = fastlanes::fs; // from fls/std/filesystem.hpp
+
+// ------------------------------------------------------------------
+// Minimal Base64 encoder for embedding JPEG bytes in CSV
+// ------------------------------------------------------------------
+static const std::string b64_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                     "abcdefghijklmnopqrstuvwxyz"
+                                     "0123456789+/";
+
+static std::string base64_encode(const std::vector<uint8_t>& buf) {
+	std::string out;
+	int         val  = 0;
+	int         valb = -6;
+	for (uint8_t c : buf) {
+		val = (val << 8) + c;
+		valb += 8;
+		while (valb >= 0) {
+			out.push_back(b64_chars[(val >> valb) & 0x3F]);
+			valb -= 6;
+		}
+	}
+	if (valb > -6) {
+		out.push_back(b64_chars[((val << 8) >> (valb + 8)) & 0x3F]);
+	}
+	while (out.size() % 4) {
+		out.push_back('=');
+	}
+	return out;
+}
+
+// ------------------------------------------------------------------
+// Read fuzz settings from fuzz_config.json
+// ------------------------------------------------------------------
+namespace fastlanes { namespace cfg {
+
+struct Settings {
+	int  num_cases = 10;  // number of TEST cases to spawn
+	int  base_seed = 42;  // starting seed, incremented per‑case
+	char delim     = '|'; // CSV delimiter
+
+	// OPTIONAL: ranges for generated data dimensions
+	int min_cols = 1;   // inclusive lower bound for #columns
+	int max_cols = 6;   // inclusive upper bound for #columns
+	int min_rows = 100; // inclusive lower bound for #rows
+	int max_rows = 100; // inclusive upper bound for #rows (defaults to 100 as before)
+};
+
+inline Settings load() {
+	Settings s;
+	using fs::path;
+	try {
+		path          cfg_path = path(FLS_CMAKE_SOURCE_DIR) / "test" / "src" / "quick_fuzz_tests" / "fuzz_config.json";
+		std::ifstream in(cfg_path);
+		if (in) {
+			nlohmann::json j;
+			in >> j;
+			if (j.contains("num_cases"))
+				s.num_cases = j["num_cases"];
+			if (j.contains("base_seed"))
+				s.base_seed = j["base_seed"];
+			if (j.contains("delimiter")) {
+				auto d = j["delimiter"].get<std::string>();
+				if (!d.empty())
+					s.delim = d[0];
+			}
+			if (j.contains("min_cols"))
+				s.min_cols = j["min_cols"];
+			if (j.contains("max_cols"))
+				s.max_cols = j["max_cols"];
+			if (j.contains("min_rows"))
+				s.min_rows = j["min_rows"];
+			if (j.contains("max_rows"))
+				s.max_rows = j["max_rows"];
+		} else {
+			std::cerr << "[cfg] Warning: cannot open " << cfg_path << "; using defaults.\n";
+		}
+	} catch (const std::exception& ex) {
+		std::cerr << "[cfg] Error parsing fuzz_config.json: " << ex.what() << "; using defaults.\n";
+	}
+	// clamp ranges if swapped in JSON
+	if (s.min_cols > s.max_cols)
+		std::swap(s.min_cols, s.max_cols);
+	if (s.min_rows > s.max_rows)
+		std::swap(s.min_rows, s.max_rows);
+	return s;
+}
+
+}} // namespace fastlanes::cfg
+
+// ------------------------------------------------------------------
+// Global settings (loaded once)
+// ------------------------------------------------------------------
+static const auto SETTINGS = fastlanes::cfg::load();
+
+// Print settings at startup
+static struct SettingsPrinter {
+	SettingsPrinter() {
+		std::cout << "Settings:"
+		          << " num_cases=" << SETTINGS.num_cases << ", base_seed=" << SETTINGS.base_seed << ", delim='"
+		          << SETTINGS.delim << "'"
+		          << ", min_cols=" << SETTINGS.min_cols << ", max_cols=" << SETTINGS.max_cols
+		          << ", min_rows=" << SETTINGS.min_rows << ", max_rows=" << SETTINGS.max_rows << std::endl;
+	}
+} settings_printer;
+
+// ------------------------------------------------------------------
+// Generate CSV + schema, round‑trip through FastLanes, compare tables
+// ------------------------------------------------------------------
+static bool run_roundtrip(int seed, int case_idx, char delim) {
+	std::mt19937 rng(seed);
+
+	auto uniform = [&](int a, int b) {
+		return a + int(rng() % (b - a + 1));
+	};
+
+	// dimensions come from JSON config; keeps signature unchanged
+	const int cols = uniform(SETTINGS.min_cols, SETTINGS.max_cols);
+	const int rows = uniform(SETTINGS.min_rows, SETTINGS.max_rows);
+
+	// column types: 0=int, 1=string, 2=jpeg; ensure ≥1 jpeg
+	std::vector<int> col_type(cols);
+	bool             saw_jpeg = false;
+	for (int c = 0; c < cols; ++c) {
+		col_type[c] = rng() % 3;
+		if (col_type[c] == 2)
+			saw_jpeg = true;
+	}
+	if (!saw_jpeg) {
+		col_type[uniform(0, cols - 1)] = 2;
+	}
+
+	// build JSON schema
+	nlohmann::json schema;
+	schema["columns"] = nlohmann::json::array();
+	for (int c = 0; c < cols; ++c) {
+		schema["columns"].push_back({{"name", "col" + std::to_string(c)},
+		                             {"type",
+		                              col_type[c] == 0   ? "integer"
+		                              : col_type[c] == 1 ? "string"
+		                                                 : "jpeg"}});
+	}
+
+	// prepare directories (images dir removed; no image files are produced)
+	fs::path root   = FLS_CMAKE_SOURCE_DIR;
+	fs::path case_d = root / "tmp" / "fls_quick_fuzz" / ("case_" + std::to_string(case_idx));
+	fs::remove_all(case_d);
+	fs::create_directories(case_d);
+
+	fs::path csv_p    = case_d / "generated.csv";
+	fs::path schema_p = case_d / "schema.json";
+	fs::path fls_p    = case_d / "data.fls";
+
+	// write schema.json
+	std::ofstream(schema_p) << schema.dump(2);
+
+	// write CSV (JPEG blobs are embedded directly; no files are touched)
+	{
+		std::ofstream csv(csv_p);
+		for (int row = 0; row < rows; ++row) {
+			std::ostringstream ss;
+			for (int c = 0; c < cols; ++c) {
+				if (c)
+					ss << delim;
+
+				switch (col_type[c]) {
+				case 0: // integer
+					ss << (rng() % 10 == 0 ? "NULL" : std::to_string(uniform(0, 1000)));
+					break;
+
+				case 1: { // string
+					int L = uniform(1, 8);
+					for (int i = 0; i < L; ++i)
+						ss << char(uniform('a', 'z'));
+				} break;
+
+				case 2: { // jpeg (tiny, random) kept fully in memory
+					std::vector<uint8_t>     img {0xFF, 0xD8};
+					static constexpr uint8_t hdr[] = {0xFF,
+					                                  0xE0,
+					                                  0x00,
+					                                  0x10,
+					                                  'J',
+					                                  'F',
+					                                  'I',
+					                                  'F',
+					                                  0x00,
+					                                  0x01,
+					                                  0x02,
+					                                  0x00,
+					                                  0x00,
+					                                  0x01,
+					                                  0x00,
+					                                  0x01,
+					                                  0x00,
+					                                  0x00};
+					img.insert(img.end(), std::begin(hdr), std::end(hdr));
+					int payload = uniform(1, 8) * 4;
+					for (int i = 0; i < payload; ++i)
+						img.push_back(uint8_t(rng() % 256));
+					img.push_back(0xFF);
+					img.push_back(0xD9);
+
+					// Embed directly in CSV via Base64; no disk I/O.
+					ss << base64_encode(img);
+				} break;
+				default:;
+				}
+			}
+			csv << ss.str() << '\n';
+		}
+	}
+
+	// round‑trip
+	fastlanes::Connection con1;
+	con1.set_n_vectors_per_rowgroup(1).read_csv(case_d).to_fls(fls_p);
+	const auto& tbl1 = con1.get_table();
+
+	fastlanes::Connection con2;
+	auto                  tbl2 = con2.reset().read_fls(fls_p)->materialize();
+
+	return (tbl1 == *tbl2).is_equal;
+}
+
+// ------------------------------------------------------------------
+// Spawn the original 10 independent TESTs (interface unchanged)
+// ------------------------------------------------------------------
+TEST(QuickFuzz_Case0, Random) {
+	EXPECT_TRUE(run_roundtrip(SETTINGS.base_seed + 0, 0, SETTINGS.delim));
+}
+TEST(QuickFuzz_Case1, Random) {
+	EXPECT_TRUE(run_roundtrip(SETTINGS.base_seed + 1, 1, SETTINGS.delim));
+}
+TEST(QuickFuzz_Case2, Random) {
+	EXPECT_TRUE(run_roundtrip(SETTINGS.base_seed + 2, 2, SETTINGS.delim));
+}
+TEST(QuickFuzz_Case3, Random) {
+	EXPECT_TRUE(run_roundtrip(SETTINGS.base_seed + 3, 3, SETTINGS.delim));
+}
+TEST(QuickFuzz_Case4, Random) {
+	EXPECT_TRUE(run_roundtrip(SETTINGS.base_seed + 4, 4, SETTINGS.delim));
+}
+TEST(QuickFuzz_Case5, Random) {
+	EXPECT_TRUE(run_roundtrip(SETTINGS.base_seed + 5, 5, SETTINGS.delim));
+}
+TEST(QuickFuzz_Case6, Random) {
+	EXPECT_TRUE(run_roundtrip(SETTINGS.base_seed + 6, 6, SETTINGS.delim));
+}
+TEST(QuickFuzz_Case7, Random) {
+	EXPECT_TRUE(run_roundtrip(SETTINGS.base_seed + 7, 7, SETTINGS.delim));
+}
+TEST(QuickFuzz_Case8, Random) {
+	EXPECT_TRUE(run_roundtrip(SETTINGS.base_seed + 8, 8, SETTINGS.delim));
+}
+TEST(QuickFuzz_Case9, Random) {
+	EXPECT_TRUE(run_roundtrip(SETTINGS.base_seed + 9, 9, SETTINGS.delim));
+}


### PR DESCRIPTION
This PR introduces a suite of quick fuzzy tests to improve FastLanes’ correctness, enforces a tracked seed for reproducible fuzz runs, and extends CI to run on all supported GitHub-hosted platforms:

* `ubuntu-24.04`
* `ubuntu-22.04`
* `ubuntu-24.04-arm`
* `ubuntu-22.04-arm`
* `macos-15`
* `macos-14`
* `macos-13`

It also resolves the CI breakage caused by GitHub Actions shifting the `ubuntu-latest` runner from Ubuntu 22.04 to Ubuntu 24.04 on June 17, 2025.

---

### What’s New

* **Seed management**

  * Configuration lives in `test/src/quick_fuzz_tests/fuzz_config.json` with a `base_seed` field.
  * **Bump check:** `scripts/verify_seed_bump.py` ensures each PR’s `base_seed` is exactly +1 over `origin/dev`; skips if no config exists on `dev`.
  * **To bump:** run `scripts/bump_fuzz_seed.py`, which increments `base_seed` by 1 (creating the file at the default seed of 42 if missing).

* **Expanded runner matrix**
  CI now runs on the full set of declared platforms:

  ```yaml
  runs-on:
    - ubuntu-24.04
    - ubuntu-22.04
    - ubuntu-24.04-arm
    - ubuntu-22.04-arm
    - macos-15
    - macos-14
    - macos-13
  ```
