### PR TITLE
fix compile error on MacOS M1 in encoding_operator.cpp:286.

### DIFF
--- a/src/expression/encoding_operator.cpp
+++ b/src/expression/encoding_operator.cpp
@@ -283,7 +283,7 @@ enc_ffor_opr<PT>::enc_ffor_opr(const PhysicalExpr& expr,
                                ColumnDescriptorT&  column_descriptor,
                                InterpreterState&   state) {
 
-	VisitorFunctor functor {this, &expr};
+	VisitorFunctor<PT> functor {this, &expr};
 
 	if (!expr.operators.empty()) {
 		visit(functor, expr.operators.back());

--- a/test/src/quick_fuzz_tests/fuzz_config.json
+++ b/test/src/quick_fuzz_tests/fuzz_config.json
@@ -1,6 +1,6 @@
 {
   "num_cases": 10,
-  "base_seed": 7,
+  "base_seed": 8,
   "delimiter": "|",
   "min_cols": 1,
   "max_cols": 2,


### PR DESCRIPTION
I met a compile error when trying FastLanes on MacOS M1: 

```
encoding_operator.cpp:286:17: error: no viable constructor or deduction guide for deduction of template arguments of 'VisitorFunctor'
        VisitorFunctor functor {this, &expr};
```

The way to fix this error is by setting `VisitorFunctor<PT> functor {this, &expr};` on line 286 of `encoding_operator.cpp`. Hope this fix would help others to use FastLanes on MacOS.