### PR TITLE
Fix File::Read, File::ReadRange and bump_fuzz_seed.py

### DIFF
--- a/scripts/bump_fuzz_seed.py
+++ b/scripts/bump_fuzz_seed.py
@@ -13,6 +13,7 @@ Usage:
 from __future__ import annotations
 import json
 from pathlib import Path
+import shutil
 import sys
 import tempfile
 
@@ -34,7 +35,7 @@ def main() -> None:
     with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
         json.dump(data, tmp, indent=2)
         tmp.write("\n")
-    Path(tmp.name).replace(CFG)
+    shutil.move(tmp.name, CFG) # Fix: Invalid cross-device link
 
     print(f"✅  base_seed bumped: {old} → {new}")
 

--- a/src/cor/lyt/buf.cpp
+++ b/src/cor/lyt/buf.cpp
@@ -127,7 +127,7 @@ void Buf::Swap(const Buf& a_buf) {
 void Buf::UnsafeAdvance(const n_t byte_c) {
 	/**/
 	FLS_ASSERT_CORRECT_N(byte_c);
-  FLS_ASSERT_LE(m_off + byte_c, m_capacity);
+	FLS_ASSERT_LE(m_off + byte_c, m_capacity);
 
 	m_off += byte_c;
 }

--- a/src/cor/lyt/buf.cpp
+++ b/src/cor/lyt/buf.cpp
@@ -127,6 +127,7 @@ void Buf::Swap(const Buf& a_buf) {
 void Buf::UnsafeAdvance(const n_t byte_c) {
 	/**/
 	FLS_ASSERT_CORRECT_N(byte_c);
+  FLS_ASSERT_LE(m_off + byte_c, m_capacity);
 
 	m_off += byte_c;
 }

--- a/src/io/file.cpp
+++ b/src/io/file.cpp
@@ -48,8 +48,8 @@ void File::Read(Buf& buf) {
 	}
 
 	auto file_size = fs::file_size(m_path);
-	FLS_ASSERT_LE(file_size, buf.Capacity())
-  buf.UnsafeAdvance(file_size);
+	FLS_ASSERT_LE(file_size, buf.Capacity());
+	buf.UnsafeAdvance(file_size);
 
 	m_if_stream->read(reinterpret_cast<char*>(buf.mutable_data()), static_cast<int64_t>(file_size));
 }
@@ -62,7 +62,7 @@ void File::ReadRange(Buf& buf, const n_t offset, const n_t size) {
 	[[maybe_unused]] auto file_size = fs::file_size(m_path);
 	FLS_ASSERT_LE(offset + size, file_size);
 	FLS_ASSERT_LE(size, buf.Capacity());
-  buf.UnsafeAdvance(size);
+	buf.UnsafeAdvance(size);
 
 	m_if_stream->seekg(static_cast<std::streamoff>(offset), std::ios::beg);
 	m_if_stream->read(reinterpret_cast<char*>(buf.mutable_data()), static_cast<std::streamsize>(size));

--- a/src/io/file.cpp
+++ b/src/io/file.cpp
@@ -49,6 +49,7 @@ void File::Read(Buf& buf) {
 
 	auto file_size = fs::file_size(m_path);
 	FLS_ASSERT_LE(file_size, buf.Capacity())
+  buf.UnsafeAdvance(file_size);
 
 	m_if_stream->read(reinterpret_cast<char*>(buf.mutable_data()), static_cast<int64_t>(file_size));
 }
@@ -61,6 +62,7 @@ void File::ReadRange(Buf& buf, const n_t offset, const n_t size) {
 	[[maybe_unused]] auto file_size = fs::file_size(m_path);
 	FLS_ASSERT_LE(offset + size, file_size);
 	FLS_ASSERT_LE(size, buf.Capacity());
+  buf.UnsafeAdvance(size);
 
 	m_if_stream->seekg(static_cast<std::streamoff>(offset), std::ios::beg);
 	m_if_stream->read(reinterpret_cast<char*>(buf.mutable_data()), static_cast<std::streamsize>(size));

--- a/test/src/quick_fuzz_tests/fuzz_config.json
+++ b/test/src/quick_fuzz_tests/fuzz_config.json
@@ -1,6 +1,6 @@
 {
   "num_cases": 10,
-  "base_seed": 12,
+  "base_seed": 13,
   "delimiter": "|",
   "min_cols": 1,
   "max_cols": 2,


### PR DESCRIPTION
* Add buf.UnsafeAdvance() before writing to buf in File::Read & ReadRange, to let buf has the correct size.
* Use shutil.move(tmp.name, CFG) in bump_fuzz_seed.py to avoid possible error: Invalid cross-device link