### PR TITLE
Fix -Wnonnull build failure in TypedStats: value-initialize last_seen_val

### DIFF
--- a/src/table/stats.cpp
+++ b/src/table/stats.cpp
@@ -14,7 +14,7 @@ template <typename PT>
 TypedStats<PT>::TypedStats()
     : min {std::numeric_limits<PT>::max()}    //
     , max {std::numeric_limits<PT>::lowest()} //
-    , last_seen_val(0)                        // NOLINT
+    , last_seen_val {}                        // NOLINT
     , n_nulls(0)
     , is_double_castable(false) {
 }


### PR DESCRIPTION
`TypedStats<PT>` is explicitly instantiated for every `PT` in `FLS_ALL_CTS`, including `str_pt`. The member initializer `last_seen_val(0)` therefore instantiates as `std::string(0)` == `std::string(nullptr)`, which is undefined behaviour. Clang 21 diagnoses it and, with the project's `-Werror`, the build fails:

```
src/table/stats.cpp:17:21: error: null passed to a callee that requires a non-null argument [-Werror,-Wnonnull]
```

Value-initializing with `{}` yields `0` for the arithmetic instantiations and an empty string for `str_pt`, so there is no behaviour change for the numeric types.

**Reproduced on:** macOS 15 / arm64, Apple clang 21, `pip install .` (scikit-build-core, Release). With this one-line change the wheel builds and a CSV -> `.fls` -> CSV roundtrip over ~112k rows x 7 BIGINT columns is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)